### PR TITLE
Remove "?download=true" from huggingface links

### DIFF
--- a/rvc/lib/tools/model_download.py
+++ b/rvc/lib/tools/model_download.py
@@ -93,6 +93,9 @@ def download_from_url(url):
             os.chdir(zips_path)
             if "/blob/" in url:
                 url = url.replace("/blob/", "/resolve/")
+            
+            if url.endswith("?download=true"):
+                url = url[:-14]
 
             response = requests.get(url, stream=True)
             if response.status_code == 200:


### PR DESCRIPTION
Basically it saved the zip file with _download_true in the name which made it impossible to unzip.
![image](https://github.com/IAHispano/Applio/assets/146493916/5dd4c90a-dce3-4066-9690-b573588cb119)
