### PR TITLE
Changed os.rename to shutil.move

### DIFF
--- a/tabs/download/download.py
+++ b/tabs/download/download.py
@@ -41,7 +41,7 @@ def save_drop_model(dropbox):
             os.makedirs(model_path)
         if os.path.exists(os.path.join(model_path, file_name)):
             os.remove(os.path.join(model_path, file_name))
-        os.rename(dropbox, os.path.join(model_path, file_name))
+        shutil.move(dropbox, os.path.join(model_path, file_name))
         print(f"{file_name} saved in {model_path}")
         gr.Info(f"{file_name} saved in {model_path}")
     return None


### PR DESCRIPTION
os.rename does not work if the folders are mounted on different filesystems. Some operating systems mount /tmp on a different filesystem (such as with mine), due to which /tmp/gradio is not able to symlink to the model in log. This solves that issue