### PR TITLE
Add fallback logic to select different server port on OSError.

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,6 +102,13 @@ with gr.Blocks(theme=my_applio, title="Applio") as Applio:
         lang_tab()
         restart_tab()
 
+def launch_gradio(port):
+    Applio.launch(
+        favicon_path="assets/ICON.ico",
+        share="--share" in sys.argv,
+        inbrowser="--open" in sys.argv,
+        server_port=port,
+    )
 
 if __name__ == "__main__":
     port = 6969
@@ -110,9 +117,17 @@ if __name__ == "__main__":
         if port_index < len(sys.argv):
             port = int(sys.argv[port_index])
 
-    Applio.launch(
-        favicon_path="assets/ICON.ico",
-        share="--share" in sys.argv,
-        inbrowser="--open" in sys.argv,
-        server_port=port,
-    )
+        launch_gradio(port)
+
+    else:
+        # if launch fails, decrement port number and try again (up to 10 times)
+        for i in range(10):
+            try:
+                launch_gradio(port)
+                break
+            except OSError:
+                print("Failed to launch on port", port, "- trying again...")
+                port -= 1
+            except Exception as e:
+                print(f'Unexpected error during launch: {e}')
+                break


### PR DESCRIPTION
Added fallback logic that selects a different port if gradio returns an `OSError`.
If the error is triggered, gradio will be launched again on a port decreased with -1.
There is a limit of max 10 attempts to prevent a infinite loop.

Why I added this:
I ran into the problem that port 6969 is already in use.
I have always fixed this issue by changing the port in the app.py to something else, but with every git pull I had to change it again and was craving for a long term solution.

Why you should consider merging:
the same problem for any other user without the technical knowledge to resolve it themselves runs into the same problem can be avoided.