### PR TITLE
automatically use the correct python executable

### DIFF
--- a/core.py
+++ b/core.py
@@ -37,6 +37,7 @@ with open(os.path.join("rvc", "lib", "tools", "tts_voices.json"), "r") as f:
 
 
 locales = list({voice["Locale"] for voice in voices_data})
+python = sys.executable
 
 
 # Infer
@@ -196,7 +197,7 @@ def run_tts_script(
         os.remove(output_tts_path)
 
     command_tts = [
-        "python",
+        python,
         tts_script_path,
         tts_text,
         tts_voice,
@@ -238,7 +239,7 @@ def run_preprocess_script(model_name, dataset_path, sampling_rate, cpu_cores):
     per = 3.0 if config.is_half else 3.7
     preprocess_script_path = os.path.join("rvc", "train", "preprocess", "preprocess.py")
     command = [
-        "python",
+        python,
         preprocess_script_path,
         *map(
             str,
@@ -278,7 +279,7 @@ def run_extract_script(
     )
 
     command_1 = [
-        "python",
+        python,
         extract_f0_script_path,
         *map(
             str,
@@ -291,7 +292,7 @@ def run_extract_script(
         ),
     ]
     command_2 = [
-        "python",
+        python,
         extract_feature_script_path,
         *map(
             str,
@@ -359,7 +360,7 @@ def run_train_script(
 
     train_script_path = os.path.join("rvc", "train", "train.py")
     command = [
-        "python",
+        python,
         train_script_path,
         *map(
             str,
@@ -409,7 +410,7 @@ def run_train_script(
 def run_index_script(model_name, rvc_version):
     index_script_path = os.path.join("rvc", "train", "process", "extract_index.py")
     command = [
-        "python",
+        python,
         index_script_path,
         os.path.join(logs_path, model_name),
         rvc_version,


### PR DESCRIPTION
currently the core.py file runs the inference scripts using the hardcoded `python` command.

this is problematic when running inside a venv because the `subprocess.run()` starts a new process without inheriting the python executable that was used to run the parent process, and results in dependency errors (since it tries to look for dependencies in the globally installed python environment instead of the current venv when running inside a venv).

by using `sys.executable`, we can solve this. it will automatically use the globally installed python when running normally, and it will use the python in the current venv when running in a venv.