### PR TITLE
Corrected resume functionary for training

### DIFF
--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -356,6 +356,7 @@ def run(
         _, _, _, epoch_str = load_checkpoint(
             latest_checkpoint_path(experiment_dir, "G_*.pth"), net_g, optim_g
         )
+        epoch_str += 1
         global_step = (epoch_str - 1) * len(train_loader)
 
     except:

--- a/rvc/train/utils.py
+++ b/rvc/train/utils.py
@@ -44,7 +44,6 @@ def load_checkpoint(checkpoint_path, model, optimizer=None, load_opt=1):
         load_opt (int, optional): Whether to load the optimizer state. Defaults to 1.
     """
     assert os.path.isfile(checkpoint_path)
-""" removed
     checkpoint_old_dict = torch.load(checkpoint_path, map_location="cpu")
     checkpoint_new_version_path = os.path.join(
         os.path.dirname(checkpoint_path),
@@ -86,12 +85,10 @@ def load_checkpoint(checkpoint_path, model, optimizer=None, load_opt=1):
         except:
             print("%s is not in the checkpoint", k)
             new_state_dict[k] = v
-""" 
-    checkpoint_dict = torch.load(checkpoint_path, map_location="cpu")           
     if hasattr(model, "module"):
-        model.module.load_state_dict(checkpoint_dict["model"], strict=False)
+        model.module.load_state_dict(new_state_dict, strict=False)
     else:
-        model.load_state_dict(checkpoint_dict["model"], strict=False)
+        model.load_state_dict(new_state_dict, strict=False)
 
     iteration = checkpoint_dict["iteration"]
     learning_rate = checkpoint_dict["learning_rate"]

--- a/rvc/train/utils.py
+++ b/rvc/train/utils.py
@@ -44,6 +44,7 @@ def load_checkpoint(checkpoint_path, model, optimizer=None, load_opt=1):
         load_opt (int, optional): Whether to load the optimizer state. Defaults to 1.
     """
     assert os.path.isfile(checkpoint_path)
+""" removed
     checkpoint_old_dict = torch.load(checkpoint_path, map_location="cpu")
     checkpoint_new_version_path = os.path.join(
         os.path.dirname(checkpoint_path),
@@ -85,10 +86,12 @@ def load_checkpoint(checkpoint_path, model, optimizer=None, load_opt=1):
         except:
             print("%s is not in the checkpoint", k)
             new_state_dict[k] = v
+""" 
+    checkpoint_dict = torch.load(checkpoint_path, map_location="cpu")           
     if hasattr(model, "module"):
-        model.module.load_state_dict(new_state_dict, strict=False)
+        model.module.load_state_dict(checkpoint_dict["model"], strict=False)
     else:
-        model.load_state_dict(new_state_dict, strict=False)
+        model.load_state_dict(checkpoint_dict["model"], strict=False)
 
     iteration = checkpoint_dict["iteration"]
     learning_rate = checkpoint_dict["learning_rate"]


### PR DESCRIPTION
corrected the training to resume so it does not overwrite the latest saved epoch

results: 

1) if the last epoch was 100, restart begins at 101
2) tensorboard shows correct output as  tfevents log contains reasonable results

loss/g/total,29.556018829345703,31104.0
loss/g/total,31.021081924438477,31320.0
loss/g/total,31.071796417236328,31536.0
loss/g/total,30.628948211669922,31752.0
loss/g/total,15.241731643676758,31968.0
loss/g/total,29.393726348876953,32184.0
loss/g/total,32.008575439453125,32400.0
loss/g/total,29.7031192779541,32616.0
loss/g/total,28.384408950805664,32832.0

after resume

loss/g/total,32.188724517822266,33000.0
loss/g/total,28.97464370727539,33110.0
loss/g/total,25.699451446533203,33220.0
loss/g/total,29.753664016723633,33330.0
loss/g/total,28.753559112548828,33440.0
loss/g/total,30.597312927246094,33550.0