### PR TITLE
Auto set maximum number of available gpus

### DIFF
--- a/rvc/configs/config.py
+++ b/rvc/configs/config.py
@@ -171,4 +171,8 @@ def get_gpu_info():
     return gpu_info
 
 def get_number_of_gpus():
-    return torch.cuda.device_count() if torch.cuda.is_available() else 0
+    if torch.cuda.is_available():
+        num_gpus = torch.cuda.device_count()
+        return '-'.join(map(str, range(num_gpus)))
+    else:
+        return "0"

--- a/rvc/configs/config.py
+++ b/rvc/configs/config.py
@@ -169,3 +169,6 @@ def get_gpu_info():
     else:
         gpu_info = "Unfortunately, there is no compatible GPU available to support your training."
     return gpu_info
+
+def get_number_of_gpus():
+    return torch.cuda.device_count() if torch.cuda.is_available() else 0

--- a/rvc/configs/config.py
+++ b/rvc/configs/config.py
@@ -175,4 +175,4 @@ def get_number_of_gpus():
         num_gpus = torch.cuda.device_count()
         return '-'.join(map(str, range(num_gpus)))
     else:
-        return "0"
+        return "-"

--- a/tabs/train/train.py
+++ b/tabs/train/train.py
@@ -11,7 +11,7 @@ from core import (
     run_index_script,
     run_prerequisites_script,
 )
-from rvc.configs.config import max_vram_gpu, get_gpu_info
+from rvc.configs.config import max_vram_gpu, get_gpu_info, get_number_of_gpus
 from rvc.lib.utils import format_title
 from tabs.settings.restart import restart_applio
 
@@ -452,7 +452,7 @@ def train_tab():
                             "Specify the number of GPUs you wish to utilize for training by entering them separated by hyphens (-)."
                         ),
                         placeholder=i18n("0 to ∞ separated by -"),
-                        value="0",
+                        value=str(get_number_of_gpus()),
                         interactive=True,
                     )
                     gr.Textbox(
@@ -646,7 +646,7 @@ def train_tab():
                                 "Specify the number of GPUs you wish to utilize for training by entering them separated by hyphens (-)."
                             ),
                             placeholder=i18n("0 to ∞ separated by -"),
-                            value="0",
+                            value=str(get_number_of_gpus()),
                             interactive=True,
                         )
                         gr.Textbox(


### PR DESCRIPTION
As the name of the PR suggests, it automatically sets the maximum number of GPUs available in the system for Extract Feature and training. This is also a temporary fix for a bug where Applio fails to start the pitch extract process when there are multiple GPUs, but only one is selected, which ends up using CPU in the process.