### PR TITLE
Change in the stop training button and fix step warning

### DIFF
--- a/assets/i18n/languages/en_US.json
+++ b/assets/i18n/languages/en_US.json
@@ -87,7 +87,7 @@
   "Synchronize the graph of the tensorbaord. Only enable this setting if you are training a new model.": "Synchronize the graph of the tensorbaord. Only enable this setting if you are training a new model.",
 
   "Start Training": "Start Training",
-  "Stop Training & Restart Applio": "Stop Training & Restart Applio",
+  "Stop Training": "Stop Training",
   "Generate Index": "Generate Index",
 
   "Export Model": "Export Model",

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -139,7 +139,7 @@ def main():
         """
         global training_file_path
         children = []
-        pid_file_path = os.path.join(experiment_dir, "train_pid.txt")
+        pid_file_path = os.path.join(current_dir, "rvc", "train", "train_pid.txt")
         with open(pid_file_path, "w") as pid_file:
             for i in range(n_gpus):
                 subproc = mp.Process(

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -137,7 +137,6 @@ def main():
         """
         Starts the training process with multi-GPU support.
         """
-        global training_file_path
         children = []
         pid_file_path = os.path.join(experiment_dir, "train_pid.txt")
         with open(pid_file_path, "w") as pid_file:

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -139,7 +139,7 @@ def main():
         """
         global training_file_path
         children = []
-        pid_file_path = os.path.join(current_dir, "rvc", "train", "train_pid.txt")
+        pid_file_path = os.path.join(experiment_dir, "train_pid.txt")
         with open(pid_file_path, "w") as pid_file:
             for i in range(n_gpus):
                 subproc = mp.Process(

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -440,6 +440,9 @@ def run(
         optim_d, gamma=config.train.lr_decay, last_epoch=epoch_str - 2
     )
 
+    optim_d.step()
+    optim_g.step()
+
     scaler = GradScaler(enabled=config.train.fp16_run)
 
     cache = []

--- a/tabs/settings/restart.py
+++ b/tabs/settings/restart.py
@@ -3,14 +3,10 @@ import os
 import sys
 
 now_dir = os.getcwd()
-pid_file_path = os.path.join(now_dir, "rvc", "train", "train_pid.txt")
 
 
-def restart_applio():
-    if os.name != "nt":
-        os.system("clear")
-    else:
-        os.system("cls")
+def stop_train(model_name: str):
+    pid_file_path = os.path.join(now_dir, "logs", model_name, "train_pid.txt")
     try:
         with open(pid_file_path, "r") as pid_file:
             pids = [int(pid) for pid in pid_file.readlines()]
@@ -19,6 +15,13 @@ def restart_applio():
         os.remove(pid_file_path)
     except:
         pass
+
+
+def restart_applio():
+    if os.name != "nt":
+        os.system("clear")
+    else:
+        os.system("cls")
     python = sys.executable
     os.execl(python, python, *sys.argv)
 

--- a/tabs/train/train.py
+++ b/tabs/train/train.py
@@ -13,7 +13,7 @@ from core import (
 )
 from rvc.configs.config import max_vram_gpu, get_gpu_info, get_number_of_gpus
 from rvc.lib.utils import format_title
-from tabs.settings.restart import restart_applio
+from tabs.settings.restart import stop_train
 
 i18n = I18nAuto()
 now_dir = os.getcwd()
@@ -729,12 +729,10 @@ def train_tab():
                 api_name="start_training",
             )
 
-            stop_train_button = gr.Button(
-                i18n("Stop Training & Restart Applio"), visible=False
-            )
+            stop_train_button = gr.Button(i18n("Stop Training"), visible=False)
             stop_train_button.click(
-                fn=restart_applio,
-                inputs=[],
+                fn=stop_train,
+                inputs=[model_name],
                 outputs=[],
             )
 


### PR DESCRIPTION
The stop training button isn't working because it's saving the pid_file in a different directory than the one the stop function expects
Edit: I changed the train button to work in a different way
Edit2: This PR also fixes the following warning
```
/lib/python3.10/site-packages/torch/optim/lr_scheduler.py:136: UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`. In PyTorch 1.1.0 and later, you should call them in the opposite order: `optimizer.step()` before `lr_scheduler.step()`.  Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate
  warnings.warn("Detected call of `lr_scheduler.step()` before `optimizer.step()`. "
```