### PR TITLE
Updated gradio version for Pydantic-core bug fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ transformers==4.44.2
 # Visualization and UI
 matplotlib==3.7.2
 tensorboard
-gradio==4.36.0
+gradio==4.43.0
 # Miscellaneous utilities
 certifi==2024.7.4; sys_platform == 'darwin'
 antlr4-python3-runtime==4.8; sys_platform == 'darwin'


### PR DESCRIPTION
## Description

This PR updates gradio version which fixes Pydantic-core 2.23.2 bug, that breaks Gradio UI.

## Motivation and Context

Without this fix WebUi would not work.
Info about bug: [https://github.com/gradio-app/gradio/issues/9278](https://github.com/gradio-app/gradio/issues/9278)
This fixes #670. 

## How has this been tested?

Was tested on Linux - Ubuntu 22.04.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
