### PR TITLE
added missing fallback for stft

### DIFF
--- a/rvc/lib/predictors/FCPE.py
+++ b/rvc/lib/predictors/FCPE.py
@@ -139,6 +139,14 @@ class STFT:
         y = torch.nn.functional.pad(y.unsqueeze(1), (pad_left, pad_right), mode=mode)
         y = y.squeeze(1)
 
+        # Zluda, fall-back to CPU for FFTs since HIP SDK has no cuFFT alternative
+        source_device = y.device
+        if y.device.type == "cuda" and torch.cuda.get_device_name().endswith(
+            "[ZLUDA]"
+        ):
+            y = y.to("cpu")
+            hann_window[keyshift_key] = hann_window[keyshift_key].to("cpu")
+
         spec = torch.stft(
             y,
             n_fft_new,
@@ -150,7 +158,7 @@ class STFT:
             normalized=False,
             onesided=True,
             return_complex=True,
-        )
+        ).to(source_device)
         spec = torch.sqrt(spec.real.pow(2) + spec.imag.pow(2) + (1e-9))
 
         # Handle keyshift and mel conversion


### PR DESCRIPTION
Added missing fall-back for Zluda for FCPE predictor torch.stft call

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
