### PR TITLE
Prevents Unicode decode errors in TTS text file upload

### DIFF
--- a/tabs/tts/tts.py
+++ b/tabs/tts/tts.py
@@ -95,7 +95,7 @@ def get_indexes():
 
 
 def process_input(file_path):
-    with open(file_path, "r") as file:
+    with open(file_path, "r", encoding="utf-8") as file:
         file_contents = file.read()
     gr.Info(f"The text from the txt file has been loaded!")
     return file_contents, None


### PR DESCRIPTION
Open text file with utf-8 encoding

Added utf-8 encoding when opening a text file upladed in tts tab to prevent unicode errors

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

Text upload fails if the text file contains non-unicode letters. Explicit utf-8 encoding when opening the file fixes this issue.

## How has this been tested?

Uploading a file with non-unicode letters resulted in a UnicodeDecodeError

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/2e3d3ed8-c0ce-4509-8e65-ffe125f5121d)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
