### PR TITLE
moved audio normalization to pre-splitting

### DIFF
--- a/rvc/train/preprocess/preprocess.py
+++ b/rvc/train/preprocess/preprocess.py
@@ -63,15 +63,11 @@ class PreProcess:
 
     def process_audio_segment(
         self,
-        audio_segment: np.ndarray,
+        normalized_audio: np.ndarray,
         sid: int,
         idx0: int,
         idx1: int,
-        process_effects: bool,
     ):
-        normalized_audio = (
-            self._normalize_audio(audio_segment) if process_effects else audio_segment
-        )
         if normalized_audio is None:
             print(f"{sid}-{idx0}-{idx1}-filtered")
             return
@@ -105,6 +101,7 @@ class PreProcess:
             audio_length = librosa.get_duration(y=audio, sr=self.sr)
             if process_effects:
                 audio = signal.lfilter(self.b_high, self.a_high, audio)
+                audio = self._normalize_audio(audio)
             if noise_reduction:
                 audio = nr.reduce_noise(
                     y=audio, sr=self.sr, prop_decrease=reduction_strength
@@ -121,18 +118,18 @@ class PreProcess:
                                 start : start + int(self.per * self.sr)
                             ]
                             self.process_audio_segment(
-                                tmp_audio, sid, idx0, idx1, process_effects
+                                tmp_audio, sid, idx0, idx1,
                             )
                             idx1 += 1
                         else:
                             tmp_audio = audio_segment[start:]
                             self.process_audio_segment(
-                                tmp_audio, sid, idx0, idx1, process_effects
+                                tmp_audio, sid, idx0, idx1,
                             )
                             idx1 += 1
                             break
             else:
-                self.process_audio_segment(audio, sid, idx0, idx1, process_effects)
+                self.process_audio_segment(audio, sid, idx0, idx1,)
         except Exception as error:
             print(f"Error processing audio: {error}")
         return audio_length


### PR DESCRIPTION
In order to avoid an unexpected volume boost of the quiet split parts

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
