### PR TITLE
fix: AttributeError: module 'numpy' has no attribute 'int'

### DIFF
--- a/rvc/infer/pipeline.py
+++ b/rvc/infer/pipeline.py
@@ -404,7 +404,7 @@ class Pipeline:
         ) + 1
         f0_mel[f0_mel <= 1] = 1
         f0_mel[f0_mel > 255] = 255
-        f0_coarse = np.rint(f0_mel).astype(np.int)
+        f0_coarse = np.rint(f0_mel).astype(int)
 
         return f0_coarse, f0bak
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
numpy.int was [deprecated in NumPy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) and was [removed in NumPy 1.24](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations).

https://stackoverflow.com/questions/74946845/attributeerror-module-numpy-has-no-attribute-int
<!--- Describe your changes in detail -->

## Motivation and Context
Motivation is to run Applio on numpy 1.24+ environments and silence the warning on numpy 1.20 to 1.23

## How has this been tested?
Tested on numpy 1.24 and 1.23

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
