### PR TITLE
macOS install fix

### DIFF
--- a/run-install.sh
+++ b/run-install.sh
@@ -13,7 +13,7 @@ log_message() {
 
 # Function to find a suitable Python version
 find_python() {
-    for py in python3.10 python3 python; do
+    for py in python3.10 python3.9 python3 python; do
         if command -v "$py" > /dev/null 2>&1; then
             echo "$py"
             return
@@ -65,7 +65,6 @@ install_ffmpeg_flatpak() {
         flatpak install --user -y flathub org.freedesktop.Platform.ffmpeg
     fi
 }
-
 
 install_python_ffmpeg() {
     log_message "Installing python-ffmpeg..."
@@ -158,7 +157,8 @@ if [ "$(uname)" = "Darwin" ]; then
         log_message "Homebrew not found. Installing Homebrew..."
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     fi
-    brew install python@3.10
+    brew install python@3.10 python@3.9 
+    brew install faiss
     export PYTORCH_ENABLE_MPS_FALLBACK=1
     export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
     export PATH="/opt/homebrew/bin:$PATH"  
@@ -169,3 +169,4 @@ elif [ "$(uname)" != "Linux" ]; then
 fi
 
 prepare_install
+

--- a/run-install.sh
+++ b/run-install.sh
@@ -13,13 +13,13 @@ log_message() {
 
 # Function to find a suitable Python version
 find_python() {
-    for py in python3.10 python3.9 python3 python; do
+    for py in python3.10 python3 python; do
         if command -v "$py" > /dev/null 2>&1; then
             echo "$py"
             return
         fi
     done
-    log_message "No compatible Python installation found. Please install Python 3.7+."
+    log_message "No compatible Python installation found. Please install Python 3.10."
     exit 1
 }
 

--- a/run-install.sh
+++ b/run-install.sh
@@ -157,7 +157,20 @@ if [ "$(uname)" = "Darwin" ]; then
         log_message "Homebrew not found. Installing Homebrew..."
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     fi
-    brew install python@3.10 python@3.9 
+
+    # Check installed Python version and install the correct Homebrew Python version ( macOS )
+    python_version=$(python3 --version | awk '{print $2}' | cut -d'.' -f1,2)
+    if [ "$python_version" = "3.9" ]; then
+        log_message "Python 3.9 detected. Installing Python 3.9 using Homebrew..."
+        brew install python@3.9
+    elif [ "$python_version" = "3.10" ]; then
+        log_message "Python 3.10 detected. Installing Python 3.10 using Homebrew..."
+        brew install python@3.10
+    else
+        log_message "Python version $python_version detected. Please use Python 3.9 or 3.10."
+        exit 1
+    fi
+
     brew install faiss
     export PYTORCH_ENABLE_MPS_FALLBACK=1
     export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0

--- a/run-install.sh
+++ b/run-install.sh
@@ -158,16 +158,14 @@ if [ "$(uname)" = "Darwin" ]; then
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     fi
 
-    # Check installed Python version and install the correct Homebrew Python version ( macOS )
+    # Check installed Python version and install the correct Homebrew Python version (macOS)
     python_version=$(python3 --version | awk '{print $2}' | cut -d'.' -f1,2)
     if [ "$python_version" = "3.9" ]; then
-        log_message "Python 3.9 detected. Installing Python 3.9 using Homebrew..."
-        brew install python@3.9
-    elif [ "$python_version" = "3.10" ]; then
-        log_message "Python 3.10 detected. Installing Python 3.10 using Homebrew..."
+        log_message "Python 3.9 detected. Installing Python 3.10 using Homebrew..."
         brew install python@3.10
-    else
-        log_message "Python version $python_version detected. Please use Python 3.9 or 3.10."
+        export PATH="/opt/homebrew/opt/python@3.10/bin:$PATH"
+    elif [ "$python_version" != "3.10" ]; then
+        log_message "Unsupported Python version detected: $python_version. Please use Python 3.10."
         exit 1
     fi
 
@@ -182,4 +180,5 @@ elif [ "$(uname)" != "Linux" ]; then
 fi
 
 prepare_install
+
 


### PR DESCRIPTION
1- Python 3.9 support: Added to the list of versions searched for in the find_python function.
2- Python installation on macOS: Python 3.9 is included as an option to install using Homebrew if it is not present.
3 - brew faiss
