### PR TITLE
Remove double torch.save

### DIFF
--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -954,20 +954,21 @@ def train_and_evaluate(
                 else net_g.state_dict()
             )
             for m in model_add:
-                if not os.path.exists(m):
-                    extract_model(
-                        ckpt=ckpt,
-                        sr=sample_rate,
-                        pitch_guidance=True,
-                        name=model_name,
-                        model_path=m,
-                        epoch=epoch,
-                        step=global_step,
-                        version=version,
-                        hps=hps,
-                        overtrain_info=overtrain_info,
-                        vocoder=vocoder,
-                    )
+                if os.path.exists(m):
+                    print(f'{m} already exists. Overwriting.')
+                extract_model(
+                    ckpt=ckpt,
+                    sr=sample_rate,
+                    pitch_guidance=True,
+                    name=model_name,
+                    model_path=m,
+                    epoch=epoch,
+                    step=global_step,
+                    version=version,
+                    hps=hps,
+                    overtrain_info=overtrain_info,
+                    vocoder=vocoder,
+                )
 
         # Check completion
         if epoch >= custom_total_epoch:

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -943,6 +943,10 @@ def train_and_evaluate(
                     )
                 )
 
+        # Clean-up old best epochs
+        for m in model_del:
+            os.remove(m)
+
         if model_add:
             ckpt = (
                 net_g.module.state_dict()
@@ -964,9 +968,6 @@ def train_and_evaluate(
                         overtrain_info=overtrain_info,
                         vocoder=vocoder,
                     )
-        # Clean-up old best epochs
-        for m in model_del:
-            os.remove(m)
 
         # Check completion
         if epoch >= custom_total_epoch:

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -960,7 +960,7 @@ def train_and_evaluate(
                         sr=sample_rate,
                         pitch_guidance=True,
                         name=model_name,
-                        model_dir=m,
+                        model_path=m,
                         epoch=epoch,
                         step=global_step,
                         version=version,

--- a/rvc/train/utils.py
+++ b/rvc/train/utils.py
@@ -102,20 +102,19 @@ def save_checkpoint(model, optimizer, learning_rate, iteration, checkpoint_path)
         "optimizer": optimizer.state_dict(),
         "learning_rate": learning_rate,
     }
-    torch.save(checkpoint_data, checkpoint_path)
 
     # Create a backwards-compatible checkpoint
-    old_version_path = checkpoint_path.replace(".pth", "_old_version.pth")
-    checkpoint_data = replace_keys_in_dict(
+    torch.save(
         replace_keys_in_dict(
-            checkpoint_data, ".parametrizations.weight.original1", ".weight_v"
+            replace_keys_in_dict(
+                checkpoint_data, ".parametrizations.weight.original1", ".weight_v"
+            ),
+            ".parametrizations.weight.original0",
+            ".weight_g",
         ),
-        ".parametrizations.weight.original0",
-        ".weight_g",
+        checkpoint_path
     )
-    torch.save(checkpoint_data, old_version_path)
 
-    os.replace(old_version_path, checkpoint_path)
     print(f"Saved model '{checkpoint_path}' (epoch {iteration})")
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Current implementation saves two copies of model, reloads from disc, modifies, then replaces the original one. This produces excessive IO during the saving (both due to reloading the model from disc, and storing it twice) which is critical for short save intervals, especially during fine-tuning.

Additionally, this fixes the model not being overwritten when re-running the training. This makes more sense due to at least two reasons:
1. Retraining the same data set with different precision produces models with the same name. So if you trained the model with a different precision before and switch, then you train generator and discriminator, but never produce a final model until new epoch.
2. Retraining in general always produces a different model, so you cannot consider an already existing model file being the same model.

## Motivation and Context

-

## How has this been tested?

Changes were tested by running the training with "Save every epoch" set to 10. See screenshots for disk write stats.

Model overwriting on save produces a log message:
![image](https://github.com/user-attachments/assets/a2cc587f-813e-4610-95d7-19ecc7be5811)

## Screenshots (if appropriate):

Before:
![image](https://github.com/user-attachments/assets/55a1d624-7dad-4f51-a6eb-7c8708137c2c)

After:
![image](https://github.com/user-attachments/assets/bcf17769-c313-4d0f-a1fd-d40573c2fa84)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
