### PR TITLE
Use NCCL and toggle libuv for compatibility with latest pytorch versions

### DIFF
--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -1,5 +1,6 @@
 import os
 import sys
+os.environ["USE_LIBUV"] = "0" if sys.platform == 'win32' else "1"
 import glob
 import json
 import torch
@@ -326,7 +327,7 @@ def run(
         writer_eval = None
 
     dist.init_process_group(
-        backend="gloo",
+        backend='gloo' if sys.platform == 'win32' or device.type != 'cuda' else 'nccl',
         init_method="env://",
         world_size=n_gpus if device.type == "cuda" else 1,
         rank=rank if device.type == "cuda" else 0,


### PR DESCRIPTION
## Description

This changes the backend from GLOO to NCCL for macOS and Linux targets using CUDA and keeping GLOO for Windows using any GPU since NCCL is not compiled for it. This also conditionally disables the use of libuv for Windows since pytorch >2.4 is compiled without libuv.
https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html#impact

This does not break compatibility with ROCm since ROCm pytorch uses RCCL under the hood:
https://discuss.pytorch.org/t/ddp-with-amd-rocm/118928/2

## Motivation and Context

This allows for the usage of latest PyTorch versions and keeping distributed training on Windows while using NCCL on other OS to improve multi-gpu CUDA performance on Linux runners.

## How has this been tested?

Run the code with Nvidia GPU on Windows and Linux. The code runs with PyTorch >2.4 on Windows, previously failed to run due to libuv error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
