### PR TITLE
Add a param `--server-name` to support providing server_name for gradio

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,7 +114,7 @@ with gr.Blocks(
     )
 
 
-def launch_gradio(server_name: str, server_port: int):
+def launch_gradio(server_name: str, server_port: int) -> None:
     Applio.launch(
         favicon_path="assets/ICON.ico",
         share="--share" in sys.argv,

--- a/app.py
+++ b/app.py
@@ -3,6 +3,9 @@ import sys
 import os
 import logging
 
+from typing import Any
+
+DEFAULT_SERVER_NAME = "127.0.0.1"
 DEFAULT_PORT = 6969
 MAX_PORT_ATTEMPTS = 10
 
@@ -62,7 +65,7 @@ my_applio = loadThemes.load_theme() or "ParityError/Interstellar"
 
 # Define Gradio interface
 with gr.Blocks(
-    theme=my_applio, title="Applio", css="footer{display:none !important}"
+        theme=my_applio, title="Applio", css="footer{display:none !important}"
 ) as Applio:
     gr.Markdown("# Applio")
     gr.Markdown(
@@ -111,28 +114,31 @@ with gr.Blocks(
     )
 
 
-def launch_gradio(port):
+def launch_gradio(server_name: str, server_port: int):
     Applio.launch(
         favicon_path="assets/ICON.ico",
         share="--share" in sys.argv,
         inbrowser="--open" in sys.argv,
-        server_port=port,
+        server_name=server_name,
+        server_port=server_port,
     )
 
 
-def get_port_from_args():
-    if "--port" in sys.argv:
-        port_index = sys.argv.index("--port") + 1
-        if port_index < len(sys.argv):
-            return int(sys.argv[port_index])
-    return DEFAULT_PORT
+def get_value_from_args(key: str, default: Any = None) -> Any:
+    if key in sys.argv:
+        index = sys.argv.index(key) + 1
+        if index < len(sys.argv):
+            return sys.argv[index]
+    return default
 
 
 if __name__ == "__main__":
-    port = get_port_from_args()
+    port = int(get_value_from_args("--port", DEFAULT_PORT))
+    server = get_value_from_args("--server-name", DEFAULT_SERVER_NAME)
+
     for _ in range(MAX_PORT_ATTEMPTS):
         try:
-            launch_gradio(port)
+            launch_gradio(server, port)
             break
         except OSError:
             print(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Remove func `get_port_from_args()`
2. Add func `get_value_from_args()` to enhance code reusability.
3. Add some type annotations to params and returns
4. Add param `--server-name <ip>` for gradio

## Motivation and Context

Some time we need to run it with ip `0.0.0.0` but now it couldn't do that.

## How has this been tested?

I run that on my local server bcz I think it is a tiny change for the code.

## Screenshots (if appropriate):

None.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
