### PR TITLE
Preserve non-ASCII characters in title formatting

### DIFF
--- a/rvc/lib/utils.py
+++ b/rvc/lib/utils.py
@@ -87,10 +87,10 @@ def load_audio_infer(
 
 def format_title(title):
     formatted_title = (
-        unicodedata.normalize("NFKD", title).encode("ascii", "ignore").decode("utf-8")
+        unicodedata.normalize("NFKD", title)
     )
     formatted_title = re.sub(r"[\u2500-\u257F]+", "", formatted_title)
-    formatted_title = re.sub(r"[^\w\s.-]", "", formatted_title)
+    formatted_title = re.sub(r"[^\w\s.-]", "", formatted_title, flags=re.UNICODE)
     formatted_title = re.sub(r"\s+", "_", formatted_title)
     return formatted_title
 

--- a/rvc/lib/utils.py
+++ b/rvc/lib/utils.py
@@ -87,7 +87,7 @@ def load_audio_infer(
 
 def format_title(title):
     formatted_title = (
-        unicodedata.normalize("NFKD", title)
+        unicodedata.normalize("NFC", title)
     )
     formatted_title = re.sub(r"[\u2500-\u257F]+", "", formatted_title)
     formatted_title = re.sub(r"[^\w\s.-]", "", formatted_title, flags=re.UNICODE)


### PR DESCRIPTION
## Description
Modified the `format_title` function to preserve non-ASCII characters (such as Chinese characters) while maintaining the existing functionality for special character handling and space replacement. Removed the ASCII encoding/decoding step and added Unicode support to regex patterns.

## Motivation and Context
The previous implementation was converting all non-ASCII characters to underscores, which resulted in loss of information for titles containing Chinese or other non-ASCII characters. This fix ensures that these characters are preserved while still cleaning up unwanted special characters.

## How has this been tested?

Tested with various input strings including:
Chinese characters: "歌曲名字-艺术家.wav" → "歌曲名字-艺术家.wav"
Mixed language: "歌曲名字-艺术家 v2.0.wav" → "歌曲名字-艺术家_v2.0.wav"
Special characters with Unicode: "歌曲名字├──艺术家.wav" → "歌曲名字艺术家.wav"
Regular ASCII text: "title-artist.wav" → "title-artist.wav"

## Screenshots (if appropriate):
N/A
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
