### PR TITLE
Allow HomeBrew installed in a different prefix

### DIFF
--- a/run-install.sh
+++ b/run-install.sh
@@ -163,7 +163,7 @@ if [ "$(uname)" = "Darwin" ]; then
     if [ "$python_version" = "3.9" ]; then
         log_message "Python 3.9 detected. Installing Python 3.10 using Homebrew..."
         brew install python@3.10
-        export PATH="/opt/homebrew/opt/python@3.10/bin:$PATH"
+        export PATH="$(brew --prefix)/opt/python@3.10/bin:$PATH"
     elif [ "$python_version" != "3.10" ]; then
         log_message "Unsupported Python version detected: $python_version. Please use Python 3.10."
         exit 1
@@ -172,7 +172,7 @@ if [ "$(uname)" = "Darwin" ]; then
     brew install faiss
     export PYTORCH_ENABLE_MPS_FALLBACK=1
     export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
-    export PATH="/opt/homebrew/bin:$PATH"  
+    export PATH="$(brew --prefix)/bin:$PATH"  
 elif [ "$(uname)" != "Linux" ]; then
     log_message "Unsupported operating system. Are you using Windows?"
     log_message "If yes, use the batch (.bat) file instead of this one!"


### PR DESCRIPTION
Not everyone has HomeBrew installed in /opt/homebrew. This uses the `brew --prefix`, which is the official way to get the prefix.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Instead of the hard path of "/opt/homebrew", the script will fetch the path from HomeBrew itself.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is for people who install HomeBrew to a different prefix than "/opt/homebrew". Some people need custom locations for disk space, clashing dependences for other programs, or any other reasons.
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Ran install script, and it works. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
Tested on my Mac Studio Apple M1 Ultra 64 GB, 48 GPU cores
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
