### PR TITLE
remove 44100 config file from list of config files.

### DIFF
--- a/rvc/configs/config.py
+++ b/rvc/configs/config.py
@@ -5,7 +5,6 @@ import os
 version_config_paths = [
     os.path.join("48000.json"),
     os.path.join("40000.json"),
-    os.path.join("44100.json"),
     os.path.join("32000.json"),
 ]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The config file for 44100 had been removed but rvc/configs/config.py was still trying to load it, causing this error:

```
Traceback (most recent call last):
  File "/home/joseph/Documents/Source/Managed/Applio/app.py", line 26, in <module>
    from tabs.extra.extra import extra_tab
  File "/home/joseph/Documents/Source/Managed/Applio/tabs/extra/extra.py", line 10, in <module>
    from tabs.extra.sections.f0_extractor import f0_extractor_tab
  File "/home/joseph/Documents/Source/Managed/Applio/tabs/extra/sections/f0_extractor.py", line 6, in <module>
    from rvc.lib.predictors.F0Extractor import F0Extractor
  File "/home/joseph/Documents/Source/Managed/Applio/rvc/lib/predictors/F0Extractor.py", line 15, in <module>
    config = Config()
  File "/home/joseph/Documents/Source/Managed/Applio/rvc/configs/config.py", line 18, in get_instance
    instances[cls] = cls(*args, **kwargs)
  File "/home/joseph/Documents/Source/Managed/Applio/rvc/configs/config.py", line 33, in __init__
    self.json_config = self.load_config_json()
  File "/home/joseph/Documents/Source/Managed/Applio/rvc/configs/config.py", line 41, in load_config_json
    with open(config_path, "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'rvc/configs/44100.json'
```

## Motivation and Context

WIthout this fix, applio does not start.

## How has this been tested?

./run-applio.sh on Linux: Applio now starts

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
