### PR TITLE
Applio.ipynb fixed

### DIFF
--- a/assets/Applio.ipynb
+++ b/assets/Applio.ipynb
@@ -71,10 +71,10 @@
         "%cd $new_name/\n",
         "clear_output()\n",
         "print(\"Installing requirements...\")\n",
-        "!uv pip install -r requirements.txt -q\n",
-        "!uv pip install torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1 --upgrade --index-url https://download.pytorch.org/whl/cu121 -q\n",
-        "!uv pip install numpy==1.23.5 -q\n",
-        "!uv pip install gradio==5.23.1\n",
+        "!uv pip install -r requirements.txt --prerelease allow -q\n",
+        "!uv pip install torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1 --upgrade --index-url https://download.pytorch.org/whl/cu121 --prerelease allow -q\n",
+        "!uv pip install numpy==1.23.5 --prerelease allow -q\n",
+        "!uv pip install gradio==5.23.1 --prerelease allow\n",
         "clear_output()\n",
         "print(\"Finished installing requirements! \")"
       ]


### PR DESCRIPTION
There is a newer version of uv 0.6.14, and requires some additional parameters.

<!--- Provide a general summary of your changes in the Title above -->
Newer version of uv requires parameter such --prerelease allow, and will not to install packages from requirements.txt without --prerelease allow parameter.
## Description

<!--- Describe your changes in detail -->
I was changing parameters for:
```
!uv pip install -r requirements.txt -q
```
to:
```
!uv pip install -r requirements.txt --prerelease allow -q
```
Also, I've changed these parameters for all Python packages inside the Install Applio cell

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required because Tensorboard and Gradio is not working without the parameter --prerelease allow using uv

## How has this been tested?
This has been tested using Google Colab, and it's working now

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I was installing the Applio using Google Colab by importing the Applio.ipynb with my changes, and it works fine.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

`x`- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

`x`- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
