### PR TITLE
Fix parameter mismatch in F0 cents conversion

### DIFF
--- a/rvc/lib/predictors/F0Extractor.py
+++ b/rvc/lib/predictors/F0Extractor.py
@@ -97,6 +97,7 @@ class F0Extractor:
         plt.ylabel("F0 (cents)")
         plt.show()
 
+    @staticmethod
     def hz_to_cents(F, F_ref=55.0):
         F_temp = np.array(F).astype(float)
         F_temp[F_temp == 0] = np.nan


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a method signature mismatch in the F0 extraction pipeline that caused a `TypeError` during conversion. The error:
```
Traceback (most recent call last):
  ...
  File "/tmp/Applio/rvc/lib/predictors/F0Extractor.py", line 88, in extract_f0
    return self.hz_to_cents(f0, librosa.midi_to_hz(0))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: F0Extractor.hz_to_cents() takes from 1 to 2 positional arguments but 3 were given
```
I turned the method to `@staticmethod` because the method is a pure mathematical operation that requires no access to instance-specific data (`self`). While we could add `self` as the first parameter to resolve the error, using `@staticmethod` better reflects the method's stateless nature and avoids misleading future developers into thinking it interacts with instance attributes.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Tested with silent input, pure tones, and real audio.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
