### PR TITLE
Fix batch with uppercase extensions

### DIFF
--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -197,7 +197,6 @@ def change_choices(model):
         for root, _, files in os.walk(audio_root_relative, topdown=False)
         for name in files
     if name.lower().endswith(tuple(sup_audioext))
-        if name.lower().endswith(tuple(sup_audioext))
         and root == audio_root_relative
         and "_output" not in name
     ]

--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -196,7 +196,8 @@ def change_choices(model):
         os.path.join(root, name)
         for root, _, files in os.walk(audio_root_relative, topdown=False)
         for name in files
-        if name.endswith(tuple(sup_audioext))
+    if name.lower().endswith(tuple(sup_audioext))
+        if name.lower().endswith(tuple(sup_audioext))
         and root == audio_root_relative
         and "_output" not in name
     ]
@@ -272,7 +273,7 @@ def delete_outputs():
     gr.Info(f"Outputs cleared!")
     for root, _, files in os.walk(audio_root_relative, topdown=False):
         for name in files:
-            if name.endswith(tuple(sup_audioext)) and name.__contains__("_output"):
+            if name.lower().endswith(tuple(sup_audioext)) and name.__contains__("_output"):
                 os.remove(os.path.join(root, name))
 
 


### PR DESCRIPTION
…uppercase file extensions. Previously, only lowercase extensions were recognized, but now files like `.WAV` or `.MP3` will be correctly processed.

Here's a summary of the changes in `tabs/inference/inference.py`:
- When identifying audio files, filenames are now converted to lowercase before checking their extensions.
- The function that updates the list of audio files also now converts filenames to lowercase.
- When deleting output files, filenames are converted to lowercase to ensure correct identification.

For testing, a dummy file named `assets/audios/test_audio.WAV` has been included.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
