### PR TITLE
feat: Add model name and pitch to output filename

### DIFF
--- a/rvc/infer/infer.py
+++ b/rvc/infer/infer.py
@@ -247,6 +247,8 @@ class VoiceConverter:
             return
 
         self.get_vc(model_path, sid)
+        self.model_name = os.path.basename(model_path)
+        self.pitch = pitch
 
         try:
             start_time = time.time()
@@ -394,7 +396,8 @@ class VoiceConverter:
             print(f"Detected {len(audio_files)} audio files for inference.")
             for a in audio_files:
                 new_input = os.path.join(audio_input_paths, a)
-                new_output = os.path.splitext(a)[0] + "_output.wav"
+                base_name, ext = os.path.splitext(a)
+                new_output = f"{base_name} pitch shift{self.pitch} {self.model_name}_output{ext}"
                 new_output = os.path.join(audio_output_path, new_output)
                 if os.path.exists(new_output):
                     continue


### PR DESCRIPTION
Resolves #1060

The output filename now includes the model name and pitch value used for the conversion.

The new filename format is:
"input audio name" pitch shift" current model name"_output."export format"

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
