### PR TITLE
Fix FileBrowser Login

### DIFF
--- a/assets/Applio_Kaggle.ipynb
+++ b/assets/Applio_Kaggle.ipynb
@@ -64,7 +64,7 @@
     "!sudo curl -fsSL https://raw.githubusercontent.com/filebrowser/get/master/get.sh | sudo bash\n",
     "!filebrowser config init\n",
     "!filebrowser config set --auth.method=noauth\n",
-    "!filebrowser users add  \"applio\" \"\" --perm.admin\n",
+    "!filebrowser users add  \"applio\" \"applio123456\" --perm.admin\n",
     "clear_output()\n",
     "print(\"Finished\")"
    ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Disabling FireBrowser Authentication will make the user with id1 the default one, but creating it with a blank password, will mess up the login, making so you can't login in FileBrowser.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It solves an issue that wouldn't let users see the files.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

It has been tested on a normal Kaggle Environment.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
