### PR TITLE
Export model for training and inferencing without overwriting previous export - Colab NoUI

### DIFF
--- a/assets/Applio_NoUI.ipynb
+++ b/assets/Applio_NoUI.ipynb
@@ -107,6 +107,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "2miFQtlfiWy_"
+      },
+      "outputs": [],
       "source": [
         "# @title Sync with Google Drive\n",
         "# @markdown 💾 Run this cell to automatically Save/Load models from your mounted drive\n",
@@ -229,13 +235,7 @@
         "else:\n",
         "  print(\"❌ Drive is not mounted, skipping model syncing\")\n",
         "  print(\"To sync your models, first mount your Google Drive and re-run this cell\")"
-      ],
-      "metadata": {
-        "cellView": "form",
-        "id": "2miFQtlfiWy_"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
@@ -381,19 +381,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "64V5TWxp05cn"
+      },
+      "outputs": [],
       "source": [
         "# @title Setup model parameters\n",
         "\n",
         "model_name = \"Darwin\" # @param {type:\"string\"}\n",
         "sample_rate = \"40k\"  # @param [\"32k\", \"40k\", \"48k\"] {allow-input: false}\n",
         "sr = int(sample_rate.rstrip(\"k\")) * 1000\n"
-      ],
-      "metadata": {
-        "cellView": "form",
-        "id": "64V5TWxp05cn"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
@@ -502,6 +502,7 @@
         "cellView": "form",
         "id": "X_eU_SoiHIQg"
       },
+      "outputs": [],
       "source": [
         "# @title Export model\n",
         "# @markdown Export model to a zip file\n",
@@ -510,32 +511,45 @@
         "EXPORT_PATH = \"/content/drive/MyDrive/ApplioExported\"\n",
         "from pathlib import Path\n",
         "\n",
+        "EXPORT_PATH = \"/content/drive/MyDrive/ApplioExported\"\n",
         "export_for = \"training\" # @param [\"training\", \"inference\"] {allow-input: false}\n",
+        "export_suffix = \"_train\" if export_for == \"training\" else \"_infer\"\n",
         "\n",
+        "# Construct paths\n",
         "logs_folder = Path(f\"/content/Applio/logs/{model_name}/\")\n",
+        "model_folder = logs_folder.parent\n",
+        "zip_name = f\"/content/{model_name}{export_suffix}.zip\"\n",
+        "\n",
+        "# Check if model directory exists\n",
         "if not (logs_folder.exists() and logs_folder.is_dir()):\n",
         "    raise FileNotFoundError(f\"{model_name} model folder not found\")\n",
         "\n",
-        "%cd {logs_folder}/..\n",
-        "if export_for == \"training\":\n",
-        "  !zip -r \"/content/{model_name}.zip\" \"{model_name}\"\n",
-        "else:\n",
-        "  # find latest trained weight file\n",
-        "  !ls -t \"{model_name}/{model_name}\"_*e_*s.pth | head -n 1 > /tmp/weight.txt\n",
-        "  weight_path = open(\"/tmp/weight.txt\", \"r\").read().strip()\n",
-        "  if weight_path == \"\":\n",
-        "    raise FileNotFoundError(\"Model has no weight file, please finish training first\")\n",
-        "  weight_name = Path(weight_path).name\n",
-        "  # command does not fail if index is missing, this is intended\n",
-        "  !zip \"/content/{model_name}.zip\" \"{model_name}/{weight_name}\" \"{model_name}/{model_name}.index\"\n",
+        "# Change working directory\n",
+        "%cd {model_folder}\n",
         "\n",
-        "if Path(\"/content/drive\").is_mount():\n",
-        "  !mkdir -p \"{EXPORT_PATH}\"\n",
-        "  !mv \"/content/{model_name}.zip\" \"{EXPORT_PATH}\" && echo \"Exported model to {EXPORT_PATH}/{model_name}.zip\"\n",
+        "# Create zip file based on export type\n",
+        "if export_for == \"training\":\n",
+        "    # Export full model folder\n",
+        "    !zip -r \"{zip_name}\" \"{model_name}\"\n",
         "else:\n",
-        "  !echo \"Drive not mounted, exporting model to /content/{model_name}.zip\""
-      ],
-      "outputs": []
+        "    # Export only for inference: weight + index\n",
+        "    !ls -t \"{model_name}/{model_name}\"_*e_*s.pth | head -n 1 > /tmp/weight.txt\n",
+        "    weight_path = open(\"/tmp/weight.txt\", \"r\").read().strip()\n",
+        "    if weight_path == \"\":\n",
+        "        raise FileNotFoundError(\"Model has no weight file, please finish training first\")\n",
+        "    weight_name = Path(weight_path).name\n",
+        "\n",
+        "    # Package the model weight and index file only\n",
+        "    !zip \"{zip_name}\" \"{model_name}/{weight_name}\" \"{model_name}/{model_name}.index\"\n",
+        "\n",
+        "# Move zip to Google Drive if mounted\n",
+        "if Path(\"/content/drive\").is_mount():\n",
+        "    !mkdir -p \"{EXPORT_PATH}\"\n",
+        "    !mv \"{zip_name}\" \"{EXPORT_PATH}\" && \n",
+        "    echo \"Exported model to {EXPORT_PATH}/{Path(zip_name).name}\"\n",
+        "else:\n",
+        "    !echo \"Drive not mounted. Exported model to {zip_name}\")\n"
+      ]
     }
   ],
   "metadata": {
@@ -544,8 +558,8 @@
       "collapsed_sections": [
         "ymMCTSD6m8qV"
       ],
-      "provenance": [],
       "private_outputs": true,
+      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the model export script to prevent overwriting of export zip files when switching between "training" and "inference" modes. The change appends `_train` or `_infer` to the zip filename, preserving both types of exports.

## Motivation and Context

Previously, both training and inference exports were saved as `{model_name}.zip`, causing one to overwrite the other. This change solves that issue by giving each export mode a distinct filename.

Fixes unintended data loss and improves workflow by allowing users to retain both training and inference exports without manual renaming.

## How has this been tested?

- Manually tested in Google Colab using a sample model name.
- Verified that:
  - `model_name_train.zip` is created during training export.
  - `model_name_infer.zip` is created during inference export.
  - Each file contains the correct contents.
  - Files are successfully moved to Google Drive if mounted.

## Screenshots (if appropriate):

_Not applicable_

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
