### PR TITLE
Improved in-dict key replacement + Make it RefineGan future-proof.

### DIFF
--- a/core.py
+++ b/core.py
@@ -507,6 +507,7 @@ def run_train_script(
     g_pretrained_path: str = None,
     d_pretrained_path: str = None,
     vocoder: str = "HiFi-GAN",
+    architecture: str = "RVC",
     checkpointing: bool = False,
 ):
 
@@ -546,6 +547,7 @@ def run_train_script(
                 overtraining_threshold,
                 cleanup,
                 vocoder,
+                architecture,
                 checkpointing,
             ],
         ),
@@ -1946,6 +1948,14 @@ def parse_arguments():
         default="HiFi-GAN",
     )
     train_parser.add_argument(
+        "--architecture",
+        type=str,
+        help="Chose the architecture to be used",
+        choices=["RVC", "Applio"],
+        default="RVC",
+        required=True,
+    )
+    train_parser.add_argument(
         "--checkpointing",
         type=lambda x: bool(strtobool(x)),
         choices=[True, False],
@@ -2370,6 +2380,7 @@ def main():
                 g_pretrained_path=args.g_pretrained_path,
                 d_pretrained_path=args.d_pretrained_path,
                 vocoder=args.vocoder,
+                architecture=args.architecture,
                 checkpointing=args.checkpointing,
             )
         elif args.mode == "index":

--- a/rvc/train/process/extract_model.py
+++ b/rvc/train/process/extract_model.py
@@ -34,6 +34,7 @@ def extract_model(
     hps,
     overtrain_info,
     vocoder,
+    architecture,
     pitch_guidance=True,
     version="v2",
 ):
@@ -98,16 +99,18 @@ def extract_model(
         opt["vocoder"] = vocoder
 
         torch.save(
-            replace_keys_in_dict(
+
+        # Backwards compatibility for mainline for "RVC" architecture
+        if architecture in ["RVC", "Fork/Applio"]:
+            opt = replace_keys_in_dict(
                 replace_keys_in_dict(
                     opt, ".parametrizations.weight.original1", ".weight_v"
                 ),
                 ".parametrizations.weight.original0",
                 ".weight_g",
-            ),
-            model_path,
-        )
+            )
 
+        torch.save(opt, model_path)
         print(f"Saved model '{model_path}' (epoch {epoch} and step {step})")
 
     except Exception as error:

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -60,7 +60,8 @@ overtraining_detector = strtobool(sys.argv[12])
 overtraining_threshold = int(sys.argv[13])
 cleanup = strtobool(sys.argv[14])
 vocoder = sys.argv[15]
-checkpointing = strtobool(sys.argv[16])
+architecture = sys.argv[16]
+checkpointing = strtobool(sys.argv[17])
 # experimental settings
 randomized = True
 optimizer = "AdamW"
@@ -468,10 +469,10 @@ def run(
     try:
         print("Starting training...")
         _, _, _, epoch_str = load_checkpoint(
-            latest_checkpoint_path(experiment_dir, "D_*.pth"), net_d, optim_d
+            architecture, latest_checkpoint_path(experiment_dir, "D_*.pth"), net_d, optim_d
         )
         _, _, _, epoch_str = load_checkpoint(
-            latest_checkpoint_path(experiment_dir, "G_*.pth"), net_g, optim_g
+            architecture, latest_checkpoint_path(experiment_dir, "G_*.pth"), net_g, optim_g
         )
         epoch_str += 1
         global_step = (epoch_str - 1) * len(train_loader)
@@ -492,7 +493,7 @@ def run(
                 del ckpt
             except Exception as e:
                 print(
-                    "The parameters of the pretrain model such as the sample rate or architecture do not match the selected model."
+                    f"The parameters of the pretrain model such as the sample rate or architecture ( detected: {architecture} ) do not match the selected model."
                 )
                 print(e)
                 sys.exit(1)
@@ -509,7 +510,7 @@ def run(
                 del ckpt
             except Exception as e:
                 print(
-                    "The parameters of the pretrain model such as the sample rate or architecture do not match the selected model."
+                    f"The parameters of the pretrain model such as the sample rate or architecture ( detected: {architecture} ) do not match the selected model."
                 )
                 print(e)
                 sys.exit(1)
@@ -970,6 +971,7 @@ def train_and_evaluate(
         if epoch % save_every_epoch == 0:
             checkpoint_suffix = f"{2333333 if save_only_latest else global_step}.pth"
             save_checkpoint(
+                architecture,
                 net_g,
                 optim_g,
                 config.train.learning_rate,
@@ -977,6 +979,7 @@ def train_and_evaluate(
                 os.path.join(experiment_dir, "G_" + checkpoint_suffix),
             )
             save_checkpoint(
+                architecture,
                 net_d,
                 optim_d,
                 config.train.learning_rate,
@@ -1030,6 +1033,7 @@ def train_and_evaluate(
                         hps=hps,
                         overtrain_info=overtrain_info,
                         vocoder=vocoder,
+                        architecture=architecture,
                     )
 
         if done:

--- a/tabs/train/train.py
+++ b/tabs/train/train.py
@@ -793,6 +793,7 @@ def train_tab():
                     g_pretrained_path,
                     d_pretrained_path,
                     vocoder,
+                    architecture,
                     checkpointing,
                 ],
                 outputs=[train_output_info],


### PR DESCRIPTION
O/

There's a redundant and completely unnecessary
( As of newer pytorch versions )
conversion of keys going on under the hood.

Upon loading the models:
```
".weight_v" --->  ".parametrizations.weight.original1"
".weight_g" ---> ".parametrizations.weight.original0"
```

And then.. upon saving:
```
".parametrizations.weight.original1" ---> ".weight_v"
".parametrizations.weight.original0" ---> ".weight_g"
( + one entry in extract_model for small weights. )
```

Generally, dr and I found it completely unnecessary and the only reason it's even here is to be backward-compatible with saved G/D ( To be exact, during resuming of the training. )

Now as to why we decided to yeet it? This can be problematic in many situations, esp if you want to experiment with new discs and stuff during pretrain making and so on.
You get the point.

We aren't using old pytorch 1.x etc, so we should move away from such sketchy solutions.

Atm, I made it conditional:
- For backwards-compatibility, it behaves as normal for "RVC" architecture ( end to end; saving and loading. ) 
- For RefineGan there's 1) If it detects old keys remapping
( from previous runs or tests? whatev. ) it restores them back to normal state and never remaps during saving. 

As a side note:
You can completely change it to never re-save in old format in both archs, but that's gonna break the compatibility with mainline, naturally.

Anyhow, this is a small redundancy and consistency fix.
Just in case, I leave the flag for RefineGan key realignment.
( If you wanna test it with on / off or something )

You can find it in:
` root/rvc/train/utils.py `
( realign_keys_for_refine = True )

Kisses ~ Noobies :*