### PR TITLE
Add ASIO driver support with multiprocessing voice changer

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,18 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 now_dir = os.getcwd()
 sys.path.append(now_dir)
 
+# Suppress ConnectionResetError on Windows when a remote peer forcibly closes the
+# connection during asyncio shutdown (WinError 10054 / ProactorBasePipeTransport).
+if sys.platform == "win32":
+    import asyncio.proactor_events as _pe
+    _orig_ccl = _pe._ProactorBasePipeTransport._call_connection_lost
+    def _ccl_patched(self, exc):
+        try:
+            _orig_ccl(self, exc)
+        except ConnectionResetError:
+            pass
+    _pe._ProactorBasePipeTransport._call_connection_lost = _ccl_patched
+
 # Zluda hijack
 import rvc.lib.zluda
 

--- a/app.py
+++ b/app.py
@@ -27,12 +27,15 @@ sys.path.append(now_dir)
 # connection during asyncio shutdown (WinError 10054 / ProactorBasePipeTransport).
 if sys.platform == "win32":
     import asyncio.proactor_events as _pe
+
     _orig_ccl = _pe._ProactorBasePipeTransport._call_connection_lost
+
     def _ccl_patched(self, exc):
         try:
             _orig_ccl(self, exc)
         except ConnectionResetError:
             pass
+
     _pe._ProactorBasePipeTransport._call_connection_lost = _ccl_patched
 
 # Zluda hijack

--- a/assets/i18n/languages/af_AF.json
+++ b/assets/i18n/languages/af_AF.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Sleep jou plugin.zip om dit te installeer",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Duur van die oorgang tussen klankstukke om klikgeluide te voorkom. Hoër waardes skep gladder oorgange, maar kan latensie verhoog.",
     "Embedder Model": "Inbedder Model",
+    "Enable ASIO": "Aktiveer ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Aktiveer ASIO-bestuurder ondersteuning. (Vereis herbegin van Applio)",
     "Enable Applio integration with Discord presence": "Aktiveer Applio-integrasie met Discord-teenwoordigheid",
     "Enable VAD": "Aktiveer VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Aktiveer formantverskuiwing. Word gebruik vir manlike na vroulike en omgekeerde omskakelings.",
@@ -134,9 +136,6 @@
     "File to Speech": "Lêer na Spraak",
     "Filter": "Filter",
     "Folder Name": "Lêergids Naam",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Vir ASIO-drywers, kies 'n spesifieke invoerkanaal. Laat op -1 vir verstek.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Vir ASIO-drywers, kies 'n spesifieke monitor-uitvoerkanaal. Laat op -1 vir verstek.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Vir ASIO-drywers, kies 'n spesifieke uitvoerkanaal. Laat op -1 vir verstek.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Vir WASAPI (Windows), gee die toepassing eksklusiewe beheer vir potensieel laer latensie.",
     "Formant Shifting": "Formantverskuiwing",
     "Fresh Training": "Vars Opleiding",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Galm Nat Versterking",
     "Reverb Width": "Galm Breedte",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Beskerm duidelike konsonante en asemhalingsgeluide om elektro-akoestiese skeur en ander artefakte te voorkom. Deur die parameter na sy maksimum waarde van 0.5 te trek, bied dit omvattende beskerming. Die vermindering van hierdie waarde kan egter die mate van beskerming verminder terwyl die indekseringseffek moontlik versag word.",
+    "Sample Rate": "Monsterkoers",
     "Sampling Rate": "Monsternemingskoers",
     "Save Every Epoch": "Stoor Elke Epog",
     "Save Every Weights": "Stoor Alle Gewigte",
@@ -326,6 +326,7 @@
     "Start": "Begin",
     "Start Training": "Begin Opleiding",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Stop",
     "Stop Training": "Stop Opleiding",
     "Stop convert": "Stop omskakeling",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Volumevlak waaronder klank as stilte behandel word en nie verwerk word nie. Help om SVE-hulpbronne te bespaar en agtergrondgeraas te verminder.",
     "Warming up... ({} blocks remaining)": "Warming up... ({} blokke oor)",
     "You can also use a custom path.": "U kan ook 'n pasgemaakte pad gebruik.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Ondersteuning](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Ondersteuning](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Monsterkoers wat vir oudio-stroom gebruik word. Ignoreer dit as die bestuurder 'n verkeerde koers aanmeld (bv. 48000 Hz in plaas van 44100 Hz)."
 }

--- a/assets/i18n/languages/am_AM.json
+++ b/assets/i18n/languages/am_AM.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "ለመጫን የእርስዎን plugin.zip ይጎትቱ",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "የሚሰነጠቁ ድምፆችን ለመከላከል በድምፅ ክፋዮች መካከል ያለው የድምፅ መደብዘዝ ቆይታ። ከፍተኛ እሴቶች ለስላሳ ሽግግሮችን ይፈጥራሉ ነገር ግን መዘግየትን ሊጨምሩ ይችላሉ።",
     "Embedder Model": "የኢምቤደር ሞዴል",
+    "Enable ASIO": "ASIO ን አንቃ",
+    "Enable ASIO driver support. (Requires restarting Applio)": "የ ASIO ድራይቨር ድጋፍን ያንቁ። ከላይ ያሉትን የቻናል ቁጥሮች አዘጋጅተው ASIO መሣሪያን እንደ ግቤት/ውፅዓት ይምረጡ። ለውጡ ተግባራዊ ለመሆን Applio ን ዳግም ማስጀመር ያስፈልጋል።(Applioን እንደገና ማስጀመር ያስፈልጋል)",
     "Enable Applio integration with Discord presence": "የ Applio ውህደትን ከ Discord መገኘት ጋር ያንቁ",
     "Enable VAD": "VAD አንቃ",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "የፎርማንት ሽግግርን አንቃ። ለወንድ ወደ ሴት እና ለተገላቢጦሽ ልወጣዎች ያገለግላል።",
@@ -134,9 +136,6 @@
     "File to Speech": "ከፋይል ወደ ንግግር",
     "Filter": "አጣራ",
     "Folder Name": "የአቃፊ ስም",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ለASIO ሾፌሮች፣ የተወሰነ የግቤት ቻናል ይመርጣል። ለነባሪው በ-1 ላይ ይተዉት።",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ለASIO ሾፌሮች፣ የተወሰነ የክትትል ውፅዓት ቻናል ይመርጣል። ለነባሪው በ-1 ላይ ይተዉት።",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ለASIO ሾፌሮች፣ የተወሰነ የውፅዓት ቻናል ይመርጣል። ለነባሪው በ-1 ላይ ይተዉት።",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "ለWASAPI (Windows)፣ ዝቅተኛ መዘግየትን ለማምጣት መተግበሪያው ብቸኛ ቁጥጥር እንዲኖረው ያደርጋል።",
     "Formant Shifting": "የፎርማንት ሽግግር",
     "Fresh Training": "አዲስ ስልጠና",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "የሪቨርብ ዌት ጌይን",
     "Reverb Width": "የሪቨርብ ስፋት",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "የኤሌክትሮ-አኮስቲክ መበጣጠስ እና ሌሎች ጉድለቶችን ለመከላከል ልዩ ተነባቢዎችን እና የአተነፋፈስ ድምፆችን ይጠብቁ። ፓራሜተሩን ወደ ከፍተኛው 0.5 እሴት መሳብ አጠቃላይ ጥበቃን ይሰጣል። ሆኖም ይህንን እሴት መቀነስ የማውጫውን ውጤት እየቀነሰ የጥበቃውን መጠን ሊቀንስ ይችላል።",
+    "Sample Rate": "የናሙና መጠን",
     "Sampling Rate": "የናሙና መጠን",
     "Save Every Epoch": "በእያንዳንዱ ኢፖክ አስቀምጥ",
     "Save Every Weights": "ሁሉንም ክብደቶች አስቀምጥ",
@@ -326,6 +326,7 @@
     "Start": "ጀምር",
     "Start Training": "ስልጠና ጀምር",
     "Status": "ሁኔታ",
+    "Stereo": "ስቴሪዮ",
     "Stop": "አቁም",
     "Stop Training": "ስልጠና አቁም",
     "Stop convert": "ልወጣ አቁም",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "ከዚህ በታች ያለው የድምፅ መጠን እንደ ጸጥታ የሚቆጠርበት እና የማይቀናበርበት ደረጃ። የCPU ሀብቶችን ለመቆጠብ እና የጀርባ ጫጫታን ለመቀነስ ይረዳል።",
     "Warming up... ({} blocks remaining)": "Warming up... ({} ብሎኮች ቀሪ)",
     "You can also use a custom path.": "ብጁ ዱካም መጠቀም ይችላሉ።",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[ድጋፍ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[ድጋፍ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "ለድምጽ ዥረት የሚያገለግለው የናሙና ሬሽዮ። ድራይቨሩ የተሳሳተ ሬሽዮ ሲያሳይ ይሄን ይቀይሩ (ለምሳሌ 44100 Hz ፈንታ 48000 Hz)።"
 }

--- a/assets/i18n/languages/ar_AR.json
+++ b/assets/i18n/languages/ar_AR.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "اسحب ملف plugin.zip لتثبيته",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "مدة التلاشي بين قطع الصوت لمنع النقرات. القيم الأعلى تنشئ انتقالات أكثر سلاسة ولكنها قد تزيد من زمن الاستجابة.",
     "Embedder Model": "نموذج التضمين",
+    "Enable ASIO": "تفعيل ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "تفعيل دعم مشغل ASIO. (يتطلب إعادة تشغيل Applio)",
     "Enable Applio integration with Discord presence": "تمكين تكامل Applio مع حالة Discord",
     "Enable VAD": "تمكين VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "تمكين إزاحة الترددات. يستخدم للتحويلات من ذكر إلى أنثى والعكس.",
@@ -134,9 +136,6 @@
     "File to Speech": "ملف إلى كلام",
     "Filter": "عامل تصفية (فلتر)",
     "Folder Name": "اسم المجلد",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "لمشغلات ASIO، يحدد قناة إدخال معينة. اتركه عند -1 للافتراضي.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "لمشغلات ASIO، يحدد قناة إخراج مراقبة معينة. اتركه عند -1 للافتراضي.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "لمشغلات ASIO، يحدد قناة إخراج معينة. اتركه عند -1 للافتراضي.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "لـ WASAPI (Windows)، يمنح التطبيق تحكمًا حصريًا لزمن استجابة أقل محتمل.",
     "Formant Shifting": "إزاحة الترددات",
     "Fresh Training": "تدريب من البداية",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "كسب رطب للصدى",
     "Reverb Width": "عرض الصدى",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "حماية الحروف الساكنة المميزة وأصوات التنفس لمنع التمزق الصوتي الكهربائي والتشوهات الأخرى. سحب المُعامِل إلى قيمته القصوى البالغة 0.5 يوفر حماية شاملة. ومع ذلك، فإن تقليل هذه القيمة قد يقلل من مدى الحماية مع احتمالية تخفيف تأثير الفهرسة.",
+    "Sample Rate": "معدل أخذ العينات",
     "Sampling Rate": "معدل العينة",
     "Save Every Epoch": "حفظ كل حقبة",
     "Save Every Weights": "حفظ كل الأوزان",
@@ -326,6 +326,7 @@
     "Start": "ابدأ",
     "Start Training": "بدء التدريب",
     "Status": "الحالة",
+    "Stereo": "ستيريو",
     "Stop": "إيقاف",
     "Stop Training": "إيقاف التدريب",
     "Stop convert": "إيقاف التحويل",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "مستوى الصوت الذي يُعتبر الصوت دونه صمتًا ولا تتم معالجته. يساعد على توفير موارد وحدة المعالجة المركزية (CPU) وتقليل الضوضاء الخلفية.",
     "Warming up... ({} blocks remaining)": "جارٍ التحضير... ({} كتل متبقية)",
     "You can also use a custom path.": "يمكنك أيضًا استخدام مسار مخصص.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[الدعم](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[الدعم](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "معدل أخذ العينات المستخدم لبث الصوت. تجاوز هذا إذا أبلغ المشغل عن معدل غير صحيح (مثلاً 48000 هرتز بدلاً من 44100 هرتز)."
 }

--- a/assets/i18n/languages/az_AZ.json
+++ b/assets/i18n/languages/az_AZ.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Quraşdırmaq üçün plugin.zip faylınızı sürükləyin",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Kliklərin qarşısını almaq üçün səs hissələri arasındakı keçidin müddəti. Daha yüksək dəyərlər daha rəvan keçidlər yaradır, lakin gecikməni artıra bilər.",
     "Embedder Model": "Daxil Edici Model",
+    "Enable ASIO": "ASIO-nu aktivləşdirin",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO sürücü dəstəyini aktivləşdirin. (Applio-nu yenidən başlatmağı tələb edir)",
     "Enable Applio integration with Discord presence": "Applio-nun Discord mövcudluğu ilə inteqrasiyasını aktivləşdirin",
     "Enable VAD": "VAD-ı Aktivləşdir",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Formant sürüşməsini aktivləşdirin. Kişidən qadına və əksinə çevirmələr üçün istifadə olunur.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fayldan Nitqə",
     "Filter": "Filtr",
     "Folder Name": "Qovluq Adı",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO drayverləri üçün xüsusi bir giriş kanalı seçir. Standart üçün -1-də saxlayın.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO drayverləri üçün xüsusi bir monitor çıxış kanalı seçir. Standart üçün -1-də saxlayın.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO drayverləri üçün xüsusi bir çıxış kanalı seçir. Standart üçün -1-də saxlayın.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) üçün potensial olaraq daha aşağı gecikmə üçün tətbiqə eksklüziv nəzarət verir.",
     "Formant Shifting": "Formant Sürüşməsi",
     "Fresh Training": "Yeni Təlim",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Reverb Nəm Gücləndirmə",
     "Reverb Width": "Reverb Genişliyi",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Elektro-akustik cırılma və digər artefaktların qarşısını almaq üçün fərqli samitləri və nəfəs səslərini qoruyun. Parametri maksimum 0.5 dəyərinə çəkmək hərtərəfli qoruma təmin edir. Lakin bu dəyərin azaldılması, indeksasiya effektini potensial olaraq yüngülləşdirərkən qorunma dərəcəsini azalda bilər.",
+    "Sample Rate": "Nümunə Dərəcəsi",
     "Sampling Rate": "Nümunə Götürmə Tezliyi",
     "Save Every Epoch": "Hər Epoxda Yadda Saxla",
     "Save Every Weights": "Hər Çəkini Yadda Saxla",
@@ -326,6 +326,7 @@
     "Start": "Başlat",
     "Start Training": "Təlimə Başla",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Dayandır",
     "Stop Training": "Təlimi Dayandır",
     "Stop convert": "Çevirməni dayandır",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Səsin səssizlik kimi qəbul edildiyi və emal edilmədiyi səs səviyyəsi. CPU resurslarına qənaət etməyə və arxa plan səs-küyünü azaltmağa kömək edir.",
     "Warming up... ({} blocks remaining)": "Hazırlanır... ({} blok qalıb)",
     "You can also use a custom path.": "Siz həmçinin xüsusi bir yoldan istifadə edə bilərsiniz.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Dəstək](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Dəstək](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Audio axını üçün istifadə edilən nümunə dərəcəsi. Sürücü yanlış dərəcə bildirirsə bunu dəyişdirin (məs. 44100 Hz əvəzinə 48000 Hz)."
 }

--- a/assets/i18n/languages/ba_BA.json
+++ b/assets/i18n/languages/ba_BA.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Prevucite vaš plugin.zip da ga instalirate",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Шартлауҙарҙы булдырмау өсөн аудио өлөштәре араһындағы шыма күсеү оҙонлоғо. Юғарыраҡ ҡиммәттәр шымараҡ күсеүҙәр булдыра, ләкин тотҡарлыҡты арттырырға мөмкин.",
     "Embedder Model": "Model embeddera",
+    "Enable ASIO": "ASIO-ны яратырыу",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO драйвер ярҙамын яратырыу. (Zahtijeva ponovno pokretanje Applio-a)",
     "Enable Applio integration with Discord presence": "Omogući Applio integraciju sa Discord prisutnošću",
     "Enable VAD": "VAD-ты ҡабыҙырға",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Omogući pomjeranje formanta. Koristi se za konverzije sa muškog na ženski glas i obrnuto.",
@@ -134,9 +136,6 @@
     "File to Speech": "Datoteka u govor",
     "Filter": "Фильтр",
     "Folder Name": "Naziv foldera",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO драйверҙары өсөн, билдәле бер инеү каналын һайлай. Стандарт буйынса ҡалдырыу өсөн -1 итеп ҡалдырығыҙ.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO драйверҙары өсөн, билдәле бер монитор сығыш каналын һайлай. Стандарт буйынса ҡалдырыу өсөн -1 итеп ҡалдырығыҙ.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO драйверҙары өсөн, билдәле бер сығыш каналын һайлай. Стандарт буйынса ҡалдырыу өсөн -1 итеп ҡалдырығыҙ.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) өсөн, тотҡарлыҡты кәметеү мөмкинлеге өсөн ҡушымтаға эксклюзив контроль бирә.",
     "Formant Shifting": "Pomjeranje formanta",
     "Fresh Training": "Novo treniranje",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Mokro pojačanje reverba",
     "Reverb Width": "Širina reverba",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Zaštitite izrazite suglasnike i zvukove disanja kako biste spriječili elektroakustično kidanje i druge artefakte. Povlačenje parametra na njegovu maksimalnu vrijednost od 0.5 nudi sveobuhvatnu zaštitu. Međutim, smanjenje ove vrijednosti može smanjiti stepen zaštite, dok potencijalno ublažava efekat indeksiranja.",
+    "Sample Rate": "Үлгө тейзеһе",
     "Sampling Rate": "Brzina uzorkovanja",
     "Save Every Epoch": "Sačuvaj svaku epohu",
     "Save Every Weights": "Sačuvaj sve težine",
@@ -326,6 +326,7 @@
     "Start": "Башларға",
     "Start Training": "Započni treniranje",
     "Status": "Статус",
+    "Stereo": "Стерео",
     "Stop": "Туҡтатырға",
     "Stop Training": "Zaustavi treniranje",
     "Stop convert": "Zaustavi pretvaranje",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Тауыш кимәле, унан түбән булғанда аудио тыныслыҡ тип һанала һәм эшкәртелмәй. CPU ресурстарын экономияларға һәм фон шау-шыуын кәметергә ярҙам итә.",
     "Warming up... ({} blocks remaining)": "Warming up... ({} blokova preostalo)",
     "You can also use a custom path.": "Možete koristiti i prilagođenu putanju.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podrška](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podrška](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Аудио ағым өсөн ҡулланылған үлгө тейзеһе. Драйвер дөрөҫ булмаған тейзе биреп, был урынды үҙгәртегеҙ (мәҫ. 44100 Hz урынына 48000 Hz)."
 }

--- a/assets/i18n/languages/be_BE.json
+++ b/assets/i18n/languages/be_BE.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Перацягніце ваш plugin.zip, каб усталяваць яго",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Працягласць згасання паміж аўдыякавалкамі для прадухілення пстрычак. Большыя значэнні ствараюць больш плыўныя пераходы, але могуць павялічыць затрымку.",
     "Embedder Model": "Мадэль эмбэдэра",
+    "Enable ASIO": "Уключыць ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Уключыць падтрымку драйвера ASIO. (Патрабуецца перазапуск Applio)",
     "Enable Applio integration with Discord presence": "Уключыць інтэграцыю Applio з прысутнасцю ў Discord",
     "Enable VAD": "Уключыць VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Уключыць зрух фармант. Выкарыстоўваецца для пераўтварэнняў з мужчынскага голасу ў жаночы і наадварот.",
@@ -134,9 +136,6 @@
     "File to Speech": "Файл у маўленне",
     "Filter": "Фільтр",
     "Folder Name": "Назва папкі",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Для драйвераў ASIO выбірае пэўны ўваходны канал. Пакіньце -1 для значэння па змаўчанні.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Для драйвераў ASIO выбірае пэўны маніторны канал выхаду. Пакіньце -1 для значэння па змаўчанні.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Для драйвераў ASIO выбірае пэўны канал выхаду. Пакіньце -1 для значэння па змаўчанні.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Для WASAPI (Windows), дае праграме эксклюзіўны кантроль для патэнцыйна меншай затрымкі.",
     "Formant Shifting": "Зрух фармант",
     "Fresh Training": "Навучанне з нуля",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Вільготнае ўзмацненне рэверберацыі",
     "Reverb Width": "Шырыня рэверберацыі",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Абарона выразных зычных і гукаў дыхання для прадухілення электраакустычных разрываў і іншых артэфактаў. Устаноўка параметра на максімальнае значэнне 0.5 забяспечвае ўсебаковую абарону. Аднак зніжэнне гэтага значэння можа паменшыць ступень абароны, патэнцыйна змякчаючы эфект індэксацыі.",
+    "Sample Rate": "Частата дыскрэтызацыі",
     "Sampling Rate": "Частата дыскрэтызацыі",
     "Save Every Epoch": "Захоўваць кожную эпоху",
     "Save Every Weights": "Захоўваць усе вагі",
@@ -326,6 +326,7 @@
     "Start": "Пачаць",
     "Start Training": "Пачаць навучанне",
     "Status": "Статус",
+    "Stereo": "Стэрэа",
     "Stop": "Спыніць",
     "Stop Training": "Спыніць навучанне",
     "Stop convert": "Спыніць пераўтварэнне",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Узровень гучнасці, ніжэй за які аўдыя лічыцца цішынёй і не апрацоўваецца. Дапамагае эканоміць рэсурсы CPU і памяншаць фонавы шум.",
     "Warming up... ({} blocks remaining)": "Разагрэў... (засталося {} блокаў)",
     "You can also use a custom path.": "Вы таксама можаце выкарыстоўваць карыстальніцкі шлях.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Падтрымка](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Падтрымка](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Частата дыскрэтызацыі для аўдыяпатоку. Замяніце гэта, калі драйвер паведамляе няправільную частату (напр. 48000 Гц замест 44100 Гц)."
 }

--- a/assets/i18n/languages/bn_BN.json
+++ b/assets/i18n/languages/bn_BN.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "আপনার plugin.zip ফাইলটি ইনস্টল করতে এখানে টেনে আনুন",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "অডিও চাঙ্কের মধ্যে ক্লিকের শব্দ প্রতিরোধ করার জন্য ফেডের সময়কাল। উচ্চ মান মসৃণ রূপান্তর তৈরি করে তবে লেটেন্সি বাড়াতে পারে।",
     "Embedder Model": "এমবেডার মডেল",
+    "Enable ASIO": "ASIO সক্ষম করুন",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO ড্রাইভার সমর্থন সক্ষম করুন। ASIO ডিভাইসটি ইনপুট/আউটপুট হিসেবে নির্বাচন করুন এবং উপরের চ্যানেল নম্বরগুলি সেট করুন। পরিবর্তন কার্যকর হতে Applio পুনরায় চালু করতে হবে।(Applio পুনরায় চালু করতে হবে)",
     "Enable Applio integration with Discord presence": "Discord presence-এর সাথে Applio ইন্টিগ্রেশন সক্রিয় করুন",
     "Enable VAD": "VAD সক্ষম করুন",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "ফরমান্ট শিফটিং সক্রিয় করুন। এটি পুরুষ থেকে মহিলা এবং বিপরীত রূপান্তরের জন্য ব্যবহৃত হয়।",
@@ -134,9 +136,6 @@
     "File to Speech": "ফাইল থেকে স্পিচ",
     "Filter": "ফিল্টার",
     "Folder Name": "ফোল্ডারের নাম",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO ড্রাইভারের জন্য, একটি নির্দিষ্ট ইনপুট চ্যানেল নির্বাচন করে। ডিফল্টের জন্য -1 রাখুন।",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO ড্রাইভারের জন্য, একটি নির্দিষ্ট মনিটর আউটপুট চ্যানেল নির্বাচন করে। ডিফল্টের জন্য -1 রাখুন।",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO ড্রাইভারের জন্য, একটি নির্দিষ্ট আউটপুট চ্যানেল নির্বাচন করে। ডিফল্টের জন্য -1 রাখুন।",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) এর জন্য, অ্যাপটিকে সম্ভাব্য কম লেটেন্সি পেতে এক্সক্লুসিভ নিয়ন্ত্রণ দেয়।",
     "Formant Shifting": "ফরমান্ট শিফটিং",
     "Fresh Training": "ফ্রেশ ট্রেনিং",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "রিভার্ব ওয়েট গেইন",
     "Reverb Width": "রিভার্ব উইডথ",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "ইলেক্ট্রো-অ্যাকোস্টিক টিয়ারিং এবং অন্যান্য আর্টিফ্যাক্ট প্রতিরোধ করতে স্বতন্ত্র ব্যঞ্জনবর্ণ এবং শ্বাস-প্রশ্বাসের শব্দ রক্ষা করুন। প্যারামিটারটিকে তার সর্বোচ্চ মান 0.5-এ টানলে ব্যাপক সুরক্ষা পাওয়া যায়। তবে, এই মান কমালে সুরক্ষার মাত্রা কমতে পারে এবং ইনডেক্সিং প্রভাব প্রশমিত হতে পারে।",
+    "Sample Rate": "স্যাম্পল রেট",
     "Sampling Rate": "স্যাম্পলিং রেট",
     "Save Every Epoch": "প্রতি এপক-এ সেভ করুন",
     "Save Every Weights": "প্রতিটি ওয়েট সেভ করুন",
@@ -326,6 +326,7 @@
     "Start": "শুরু",
     "Start Training": "ট্রেনিং শুরু করুন",
     "Status": "স্ট্যাটাস",
+    "Stereo": "স্টেরিও",
     "Stop": "থামান",
     "Stop Training": "ট্রেনিং বন্ধ করুন",
     "Stop convert": "রূপান্তর বন্ধ করুন",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "যে ভলিউম লেভেলের নিচে অডিওকে নীরবতা হিসাবে ধরা হয় এবং প্রসেস করা হয় না। এটি CPU রিসোর্স বাঁচাতে এবং ব্যাকগ্রাউন্ডের শব্দ কমাতে সাহায্য করে।",
     "Warming up... ({} blocks remaining)": "ওয়ার্মিং আপ... ({} ব্লক বাকি)",
     "You can also use a custom path.": "আপনি একটি কাস্টম পাথও ব্যবহার করতে পারেন।",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[সাপোর্ট](https://discord.gg/urxFjYmYYh) — [গিটহাব](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[সাপোর্ট](https://discord.gg/urxFjYmYYh) — [গিটহাব](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "অডিও স্ট্রিমিংয়ের জন্য ব্যবহৃত স্যাম্পল রেট। ড্রাইভার ভুল রেট রিপোর্ট করলে এটি পরিবর্তন করুন (যেমন 44100 Hz এর পরিবর্তে 48000 Hz)।"
 }

--- a/assets/i18n/languages/bs_BS.json
+++ b/assets/i18n/languages/bs_BS.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Prevucite vaš plugin.zip da ga instalirate",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Trajanje postepenog prelaza (fade) između audio isječaka kako bi se spriječili klikovi. Veće vrijednosti stvaraju glađe prelaze, ali mogu povećati latenciju.",
     "Embedder Model": "Model embeddera",
+    "Enable ASIO": "Omogući ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Omogući podršku za ASIO drajver. (Zahtijeva ponovno pokretanje Applio aplikacije)",
     "Enable Applio integration with Discord presence": "Omogući Applio integraciju sa Discord prisutnošću",
     "Enable VAD": "Omogući VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Omogući pomicanje formanata. Koristi se za konverzije iz muškog u ženski glas i obrnuto.",
@@ -134,9 +136,6 @@
     "File to Speech": "Datoteka u govor",
     "Filter": "Filter",
     "Folder Name": "Naziv foldera",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Za ASIO drajvere, bira specifičan ulazni kanal. Ostavite na -1 za zadanu vrijednost.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Za ASIO drajvere, bira specifičan izlazni kanal za praćenje (monitor). Ostavite na -1 za zadanu vrijednost.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Za ASIO drajvere, bira specifičan izlazni kanal. Ostavite na -1 za zadanu vrijednost.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Za WASAPI (Windows), daje aplikaciji ekskluzivnu kontrolu za potencijalno nižu latenciju.",
     "Formant Shifting": "Pomicanje formanata",
     "Fresh Training": "Svježe treniranje",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Mokro pojačanje reverba",
     "Reverb Width": "Širina reverba",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Zaštitite izražene suglasnike i zvukove disanja kako biste spriječili elektro-akustičko kidanje i druge artefakte. Postavljanje parametra na maksimalnu vrijednost od 0.5 nudi sveobuhvatnu zaštitu. Međutim, smanjenje ove vrijednosti može umanjiti stepen zaštite, dok potencijalno ublažava efekat indeksiranja.",
+    "Sample Rate": "Frekvencija uzorkovanja",
     "Sampling Rate": "Brzina uzorkovanja",
     "Save Every Epoch": "Spremi svaku epohu",
     "Save Every Weights": "Spremi sve težine",
@@ -326,6 +326,7 @@
     "Start": "Pokreni",
     "Start Training": "Započni treniranje",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Zaustavi",
     "Stop Training": "Zaustavi treniranje",
     "Stop convert": "Zaustavi konverziju",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Nivo jačine zvuka ispod kojeg se audio tretira kao tišina i ne obrađuje se. Pomaže u uštedi CPU resursa i smanjenju pozadinske buke.",
     "Warming up... ({} blocks remaining)": "Zagrijavanje... ({} blokova preostalo)",
     "You can also use a custom path.": "Možete koristiti i prilagođenu putanju.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podrška](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podrška](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Frekvencija uzorkovanja korištena za audio prijenos. Zamijeni ovo ako drajver prijavi netačnu frekvenciju (npr. 48000 Hz umjesto 44100 Hz)."
 }

--- a/assets/i18n/languages/ca_CA.json
+++ b/assets/i18n/languages/ca_CA.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Arrossega el teu plugin.zip per instal·lar-lo",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Durada de la fosa entre fragments d'àudio per evitar clics. Valors més alts creen transicions més suaus però poden augmentar la latència.",
     "Embedder Model": "Model d'Embedder",
+    "Enable ASIO": "Activa ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Activa el suport del controlador ASIO. (Requereix reiniciar Applio)",
     "Enable Applio integration with Discord presence": "Activa la integració d'Applio amb la presència de Discord",
     "Enable VAD": "Activar VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Activa el desplaçament de formants. S'utilitza per a conversions de masculí a femení i viceversa.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fitxer a veu",
     "Filter": "Filtre",
     "Folder Name": "Nom de la carpeta",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Per a controladors ASIO, selecciona un canal d'entrada específic. Deixeu-ho a -1 per al valor per defecte.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Per a controladors ASIO, selecciona un canal de sortida de monitorització específic. Deixeu-ho a -1 per al valor per defecte.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Per a controladors ASIO, selecciona un canal de sortida específic. Deixeu-ho a -1 per al valor per defecte.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Per a WASAPI (Windows), dona a l'aplicació control exclusiu per a una latència potencialment més baixa.",
     "Formant Shifting": "Desplaçament de formants",
     "Fresh Training": "Entrenament des de zero",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Guany humit de la reverberació",
     "Reverb Width": "Amplada de la reverberació",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Protegeix les consonants sordes i els sons de respiració per prevenir el 'tearing' electroacústic i altres artefactes. Portar el paràmetre al seu valor màxim de 0.5 ofereix una protecció completa. No obstant això, reduir aquest valor pot disminuir el grau de protecció mentre potencialment mitiga l'efecte d'indexació.",
+    "Sample Rate": "Freqüència de mostreig",
     "Sampling Rate": "Taxa de mostreig",
     "Save Every Epoch": "Desar a cada època",
     "Save Every Weights": "Desar tots els pesos",
@@ -326,6 +326,7 @@
     "Start": "Iniciar",
     "Start Training": "Començar entrenament",
     "Status": "Estat",
+    "Stereo": "Estèreo",
     "Stop": "Aturar",
     "Stop Training": "Aturar entrenament",
     "Stop convert": "Aturar conversió",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Nivell de volum per sota del qual l'àudio es considera silenci i no es processa. Ajuda a estalviar recursos de la CPU i a reduir el soroll de fons.",
     "Warming up... ({} blocks remaining)": "Escalfant... ({} blocs restants)",
     "You can also use a custom path.": "També pots utilitzar una ruta personalitzada.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suport](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suport](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Freqüència de mostreig per al flux d'àudio. Canvia-ho si el controlador informa d'una freqüència incorrecta (p. ex. 48000 Hz en lloc de 44100 Hz)."
 }

--- a/assets/i18n/languages/ceb_CEB.json
+++ b/assets/i18n/languages/ceb_CEB.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "I-drag ang imong plugin.zip aron i-install kini",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Gidugayon sa fade tali sa mga tipik sa audio aron malikayan ang mga pag-klik. Ang mas taas nga mga bili makahimo og mas hapsay nga mga transisyon apan mahimong makapadugang sa latency.",
     "Embedder Model": "Modelo sa Embedder",
+    "Enable ASIO": "I-enable ang ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "I-enable ang suporta sa ASIO driver. (Nagkinahanglan og pag-restart sa Applio)",
     "Enable Applio integration with Discord presence": "I-enable ang Applio integration sa presensya sa Discord",
     "Enable VAD": "I-on ang VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "I-enable ang formant shifting. Gigamit alang sa mga conversion gikan sa lalaki ngadto sa babaye ug vice-versa.",
@@ -134,9 +136,6 @@
     "File to Speech": "File ngadto sa Pagsulti",
     "Filter": "Filter",
     "Folder Name": "Ngalan sa Folder",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Alang sa mga ASIO driver, nagpili og usa ka piho nga input channel. Biyai sa -1 para sa default.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Alang sa mga ASIO driver, nagpili og usa ka piho nga monitor output channel. Biyai sa -1 para sa default.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Alang sa mga ASIO driver, nagpili og usa ka piho nga output channel. Biyai sa -1 para sa default.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Alang sa WASAPI (Windows), naghatag sa app og eksklusibong kontrol para sa posibleng mas ubos nga latency.",
     "Formant Shifting": "Pagbalhin sa Formant",
     "Fresh Training": "Bag-ong Pagbansay",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Wet Gain sa Reverb",
     "Reverb Width": "Lapad sa Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Panalipdi ang lahi nga mga consonant ug mga tingog sa pagginhawa aron mapugngan ang electro-acoustic tearing ug uban pang mga artifact. Ang pagbira sa parameter sa iyang maximum nga bili nga 0.5 nagtanyag og komprehensibong proteksyon. Apan, ang pagkunhod niini nga bili mahimong makapakunhod sa gidak-on sa proteksyon samtang posibleng makapaminus sa epekto sa pag-index.",
+    "Sample Rate": "Sample Rate",
     "Sampling Rate": "Sampling Rate",
     "Save Every Epoch": "I-save Matag Epoch",
     "Save Every Weights": "I-save Matag Weight",
@@ -326,6 +326,7 @@
     "Start": "Sugdi",
     "Start Training": "Sugdi ang Pagbansay",
     "Status": "Kahimtang",
+    "Stereo": "Stereo",
     "Stop": "Hunonga",
     "Stop Training": "Hunonga ang Pagbansay",
     "Stop convert": "Hunonga ang pag-convert",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Lebel sa volume diin sa ubos niini ang audio isipon nga kahilom ug dili i-proseso. Makatabang sa pagdaginot sa mga kapanguhaan sa CPU ug pagkunhod sa kasaba sa palibot.",
     "Warming up... ({} blocks remaining)": "Nag-init... ({} ka block ang nahabilin)",
     "You can also use a custom path.": "Mahimo ka usab mogamit og custom nga dalanan.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suporta](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suporta](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Sample rate nga gigamit alang sa audio streaming. I-override kini kung ang driver nagrepport og sayop nga rate (hal. 48000 Hz imbes nga 44100 Hz)."
 }

--- a/assets/i18n/languages/cs_CS.json
+++ b/assets/i18n/languages/cs_CS.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Přetáhněte soubor plugin.zip pro instalaci",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Doba trvání prolínání mezi zvukovými chunky pro zamezení praskání. Vyšší hodnoty vytvářejí plynulejší přechody, ale mohou zvýšit latenci.",
     "Embedder Model": "Model embedderu",
+    "Enable ASIO": "Povolit ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Aktivujte podporu ovladače ASIO. (Vyžaduje restartování Applio)",
     "Enable Applio integration with Discord presence": "Povolit integraci Applio s Discord presence",
     "Enable VAD": "Povolit VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Povolit posun formantů. Používá se pro konverze z mužského na ženský hlas a naopak.",
@@ -134,9 +136,6 @@
     "File to Speech": "Soubor na řeč",
     "Filter": "Filtr",
     "Folder Name": "Název složky",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Pro ovladače ASIO, vybere konkrétní vstupní kanál. Ponechte -1 pro výchozí.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Pro ovladače ASIO, vybere konkrétní výstupní kanál pro odposlech. Ponechte -1 pro výchozí.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Pro ovladače ASIO, vybere konkrétní výstupní kanál. Ponechte -1 pro výchozí.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Pro WASAPI (Windows), dává aplikaci exkluzivní kontrolu pro potenciálně nižší latenci.",
     "Formant Shifting": "Posun formantů",
     "Fresh Training": "Nové trénování",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Mokrý zisk dozvuku (Wet Gain)",
     "Reverb Width": "Šířka dozvuku",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Chraňte zřetelné souhlásky a zvuky dýchání, abyste předešli elektroakustickému trhání a dalším artefaktům. Nastavení parametru na maximální hodnotu 0,5 nabízí komplexní ochranu. Snížení této hodnoty však může snížit míru ochrany a zároveň potenciálně zmírnit efekt indexování.",
+    "Sample Rate": "Vzorkovací frekvence",
     "Sampling Rate": "Vzorkovací frekvence",
     "Save Every Epoch": "Uložit každou epochu",
     "Save Every Weights": "Uložit všechny váhy",
@@ -326,6 +326,7 @@
     "Start": "Spustit",
     "Start Training": "Spustit trénování",
     "Status": "Stav",
+    "Stereo": "Stereo",
     "Stop": "Zastavit",
     "Stop Training": "Zastavit trénování",
     "Stop convert": "Zastavit převod",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Úroveň hlasitosti, pod kterou je zvuk považován za ticho a není zpracováván. Pomáhá šetřit zdroje CPU a redukovat šum na pozadí.",
     "Warming up... ({} blocks remaining)": "Zahřívání... (zbývá {} bloků)",
     "You can also use a custom path.": "Můžete také použít vlastní cestu.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podpora](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podpora](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Vzorkovací frekvence používaná pro audio stream. Změňte toto, pokud ovladač hlásí nesprávnou frekvenci (např. 48000 Hz místo 44100 Hz)."
 }

--- a/assets/i18n/languages/de_DE.json
+++ b/assets/i18n/languages/de_DE.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Ziehen Sie Ihre plugin.zip hierher, um es zu installieren",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Dauer der Überblendung zwischen Audio-Chunks, um Klickgeräusche zu vermeiden. Höhere Werte erzeugen sanftere Übergänge, können aber die Latenz erhöhen.",
     "Embedder Model": "Embedder-Modell",
+    "Enable ASIO": "ASIO aktivieren",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO-Treiber-Unterstützung aktivieren. (Erfordert einen Neustart von Applio)",
     "Enable Applio integration with Discord presence": "Applio-Integration mit Discord-Präsenz aktivieren",
     "Enable VAD": "VAD aktivieren",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Formantverschiebung aktivieren. Wird für Umwandlungen von männlich zu weiblich und umgekehrt verwendet.",
@@ -134,9 +136,6 @@
     "File to Speech": "Datei zu Sprache",
     "Filter": "Filter",
     "Folder Name": "Ordnername",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Wählt für ASIO-Treiber einen bestimmten Eingangskanal aus. Für Standardeinstellung bei -1 belassen.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Wählt für ASIO-Treiber einen bestimmten Monitor-Ausgangskanal aus. Für Standardeinstellung bei -1 belassen.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Wählt für ASIO-Treiber einen bestimmten Ausgangskanal aus. Für Standardeinstellung bei -1 belassen.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Gibt der App für WASAPI (Windows) exklusive Kontrolle für potenziell niedrigere Latenz.",
     "Formant Shifting": "Formantverschiebung",
     "Fresh Training": "Neues Training",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Hall-Nassverstärkung",
     "Reverb Width": "Hall-Breite",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Schützen Sie ausgeprägte Konsonanten und Atemgeräusche, um elektroakustisches Reißen und andere Artefakte zu verhindern. Das Setzen des Parameters auf seinen Maximalwert von 0.5 bietet umfassenden Schutz. Eine Verringerung dieses Wertes kann jedoch den Schutzumfang verringern und gleichzeitig möglicherweise den Indexierungseffekt abschwächen.",
+    "Sample Rate": "Abtastrate",
     "Sampling Rate": "Abtastrate",
     "Save Every Epoch": "Jede Epoche speichern",
     "Save Every Weights": "Alle Gewichte speichern",
@@ -326,6 +326,7 @@
     "Start": "Starten",
     "Start Training": "Training starten",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Stoppen",
     "Stop Training": "Training beenden",
     "Stop convert": "Umwandlung stoppen",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Lautstärkepegel, unter dem Audio als Stille behandelt und nicht verarbeitet wird. Hilft, CPU-Ressourcen zu sparen und Hintergrundgeräusche zu reduzieren.",
     "Warming up... ({} blocks remaining)": "Aufwärmen... ({} Blöcke verbleibend)",
     "You can also use a custom path.": "Sie können auch einen benutzerdefinierten Pfad verwenden.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Abtastrate für den Audio-Stream. Ändere diesen Wert, wenn der Treiber eine falsche Rate meldet (z.B. 48000 Hz statt 44100 Hz)."
 }

--- a/assets/i18n/languages/el_EL.json
+++ b/assets/i18n/languages/el_EL.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Σύρετε το plugin.zip σας για να το εγκαταστήσετε",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Διάρκεια του σβησίματος (fade) μεταξύ των τεμαχίων ήχου για την αποφυγή «κλικ». Υψηλότερες τιμές δημιουργούν ομαλότερες μεταβάσεις αλλά μπορεί να αυξήσουν την καθυστέρηση (latency).",
     "Embedder Model": "Μοντέλο Ενσωματωτή",
+    "Enable ASIO": "Ενεργοποίηση ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Ενεργοποίηση υποστήριξης προγράμματος οδήγησης ASIO. (Απαιτεί επανεκκίνηση του Applio)",
     "Enable Applio integration with Discord presence": "Ενεργοποίηση ενσωμάτωσης του Applio με την παρουσία στο Discord",
     "Enable VAD": "Ενεργοποίηση VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Ενεργοποίηση μετατόπισης formant. Χρησιμοποιείται για μετατροπές από ανδρική σε γυναικεία φωνή και αντίστροφα.",
@@ -134,9 +136,6 @@
     "File to Speech": "Αρχείο σε Ομιλία",
     "Filter": "Φίλτρο",
     "Folder Name": "Όνομα Φακέλου",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Για προγράμματα οδήγησης ASIO, επιλέγει ένα συγκεκριμένο κανάλι εισόδου. Αφήστε στο -1 για την προεπιλογή.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Για προγράμματα οδήγησης ASIO, επιλέγει ένα συγκεκριμένο κανάλι εξόδου παρακολούθησης (monitor). Αφήστε στο -1 για την προεπιλογή.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Για προγράμματα οδήγησης ASIO, επιλέγει ένα συγκεκριμένο κανάλι εξόδου. Αφήστε στο -1 για την προεπιλογή.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Για WASAPI (Windows), δίνει στην εφαρμογή αποκλειστικό έλεγχο για δυνητικά χαμηλότερη καθυστέρηση (latency).",
     "Formant Shifting": "Μετατόπιση Formant",
     "Fresh Training": "Εκπαίδευση από την Αρχή",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Ενίσχυση Wet Αντήχησης",
     "Reverb Width": "Εύρος Αντήχησης",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Προστατέψτε τα ευδιάκριτα σύμφωνα και τους ήχους της αναπνοής για να αποτρέψετε το ηλεκτροακουστικό σκίσιμο και άλλα τεχνουργήματα (artifacts). Η μετακίνηση της παραμέτρου στη μέγιστη τιμή της, 0.5, προσφέρει ολοκληρωμένη προστασία. Ωστόσο, η μείωση αυτής της τιμής μπορεί να μειώσει το βαθμό προστασίας, ενώ πιθανώς να μετριάσει την επίδραση της ευρετηρίασης.",
+    "Sample Rate": "Ρυθμός δειγματοληψίας",
     "Sampling Rate": "Ρυθμός Δειγματοληψίας",
     "Save Every Epoch": "Αποθήκευση Κάθε Εποχή",
     "Save Every Weights": "Αποθήκευση Όλων των Βαρών",
@@ -326,6 +326,7 @@
     "Start": "Έναρξη",
     "Start Training": "Έναρξη Εκπαίδευσης",
     "Status": "Κατάσταση",
+    "Stereo": "Στερεοφωνικό",
     "Stop": "Διακοπή",
     "Stop Training": "Διακοπή Εκπαίδευσης",
     "Stop convert": "Διακοπή μετατροπής",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Επίπεδο έντασης κάτω από το οποίο ο ήχος θεωρείται σιγή και δεν επεξεργάζεται. Βοηθά στην εξοικονόμηση πόρων CPU και στη μείωση του θορύβου περιβάλλοντος.",
     "Warming up... ({} blocks remaining)": "Προθέρμανση... ({} μπλοκ απομένουν)",
     "You can also use a custom path.": "Μπορείτε επίσης να χρησιμοποιήσετε μια προσαρμοσμένη διαδρομή.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Υποστήριξη](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Υποστήριξη](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Ρυθμός δειγματοληψίας που χρησιμοποιείται για ροή ήχου. Παρακάμψτε αυτό αν ο οδηγός αναφέρει λάθος ρυθμό (π.χ. 48000 Hz αντί 44100 Hz)."
 }

--- a/assets/i18n/languages/en_US.json
+++ b/assets/i18n/languages/en_US.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Drag your plugin.zip to install it",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.",
     "Embedder Model": "Embedder Model",
+    "Enable ASIO": "Enable ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Enable ASIO driver support. (Requires restarting Applio)",
     "Enable Applio integration with Discord presence": "Enable Applio integration with Discord presence",
     "Enable VAD": "Enable VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Enable formant shifting. Used for male to female and vice-versa convertions.",
@@ -134,9 +136,6 @@
     "File to Speech": "File to Speech",
     "Filter": "Filter",
     "Folder Name": "Folder Name",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "For ASIO drivers, selects a specific input channel. Leave at -1 for default.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "For ASIO drivers, selects a specific output channel. Leave at -1 for default.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.",
     "Formant Shifting": "Formant Shifting",
     "Fresh Training": "Fresh Training",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Reverb Wet Gain",
     "Reverb Width": "Reverb Width",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.",
+    "Sample Rate": "Sample Rate",
     "Sampling Rate": "Sampling Rate",
     "Save Every Epoch": "Save Every Epoch",
     "Save Every Weights": "Save Every Weights",
@@ -326,6 +326,7 @@
     "Start": "Start",
     "Start Training": "Start Training",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Stop",
     "Stop Training": "Stop Training",
     "Stop convert": "Stop convert",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.",
     "Warming up... ({} blocks remaining)": "Warming up... ({} blocks remaining)",
     "You can also use a custom path.": "You can also use a custom path.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values."
 }

--- a/assets/i18n/languages/es_ES.json
+++ b/assets/i18n/languages/es_ES.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Arrastra tu plugin.zip para instalarlo",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Duración del fundido entre fragmentos de audio para evitar clics. Valores más altos crean transiciones más suaves pero pueden aumentar la latencia.",
     "Embedder Model": "Modelo de Embedder",
+    "Enable ASIO": "Habilitar ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Habilitar el soporte del controlador ASIO. (Requiere reiniciar Applio)",
     "Enable Applio integration with Discord presence": "Habilitar la integración de Applio con la presencia de Discord",
     "Enable VAD": "Activar VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Habilita el desplazamiento de formantes. Usado para conversiones de hombre a mujer y viceversa.",
@@ -134,9 +136,6 @@
     "File to Speech": "Archivo a Voz",
     "Filter": "Filtro",
     "Folder Name": "Nombre de la Carpeta",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Para drivers ASIO, selecciona un canal de entrada específico. Dejar en -1 para el valor predeterminado.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Para drivers ASIO, selecciona un canal de salida de monitoreo específico. Dejar en -1 para el valor predeterminado.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Para drivers ASIO, selecciona un canal de salida específico. Dejar en -1 para el valor predeterminado.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Para WASAPI (Windows), otorga a la aplicación control exclusivo para una latencia potencialmente menor.",
     "Formant Shifting": "Desplazamiento de Formantes",
     "Fresh Training": "Entrenamiento desde Cero",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Ganancia Húmeda de la Reverb",
     "Reverb Width": "Anchura de la Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Protege las consonantes sordas y los sonidos de respiración para prevenir el desgarro electroacústico y otros artefactos. Llevar el parámetro a su valor máximo de 0.5 ofrece una protección completa. Sin embargo, reducir este valor puede disminuir el grado de protección mientras que potencialmente mitiga el efecto de la indexación.",
+    "Sample Rate": "Frecuencia de muestreo",
     "Sampling Rate": "Tasa de Muestreo",
     "Save Every Epoch": "Guardar en Cada Época",
     "Save Every Weights": "Guardar Todos los Pesos",
@@ -326,6 +326,7 @@
     "Start": "Iniciar",
     "Start Training": "Iniciar Entrenamiento",
     "Status": "Estado",
+    "Stereo": "Estéreo",
     "Stop": "Detener",
     "Stop Training": "Detener Entrenamiento",
     "Stop convert": "Detener conversión",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Nivel de volumen por debajo del cual el audio se considera silencio y no se procesa. Ayuda a ahorrar recursos de la CPU y a reducir el ruido de fondo.",
     "Warming up... ({} blocks remaining)": "Calentando... ({} bloques restantes)",
     "You can also use a custom path.": "También puedes usar una ruta personalizada.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Soporte](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Soporte](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Frecuencia de muestreo utilizada para la transmisión de audio. Anula esto si el controlador reporta una frecuencia incorrecta (p. ej. 48000 Hz en lugar de 44100 Hz)."
 }

--- a/assets/i18n/languages/eu_EU.json
+++ b/assets/i18n/languages/eu_EU.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Arrastatu zure plugin.zip fitxategia instalatzeko",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Audio-zatien arteko fundituaren iraupena klikak saihesteko. Balio altuagoek trantsizio leunagoak sortzen dituzte, baina latentzia handitu dezakete.",
     "Embedder Model": "Embedder Eredua",
+    "Enable ASIO": "Gaitu ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Gaitu ASIO gidari-laguntza. (Applio berrabiaraztea eskatzen du)",
     "Enable Applio integration with Discord presence": "Gaitu Applioren integrazioa Discord-eko presentziarekin",
     "Enable VAD": "Gaitu VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Gaitu formanteen aldaketa. Gizonetik emakumera eta alderantzizko bihurketetarako erabiltzen da.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fitxategitik Hitzera",
     "Filter": "Iragazkia",
     "Folder Name": "Karpetaren Izena",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO driverrentzat, sarrerako kanal espezifiko bat hautatzen du. Utzi -1 balioan lehenetsitakoa erabiltzeko.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO driverrentzat, monitorearen irteerako kanal espezifiko bat hautatzen du. Utzi -1 balioan lehenetsitakoa erabiltzeko.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO driverrentzat, irteerako kanal espezifiko bat hautatzen du. Utzi -1 balioan lehenetsitakoa erabiltzeko.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) erabiltzean, aplikazioari kontrol esklusiboa ematen dio, potentzialki latentzia txikiagoa lortzeko.",
     "Formant Shifting": "Formanteen Aldaketa",
     "Fresh Training": "Entrenamendu Berria",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Reverb Irabazi Hezea",
     "Reverb Width": "Reverb Zabalera",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Babestu kontsonante bereizgarriak eta arnasketa soinuak urradura elektro-akustikoa eta beste artefaktu batzuk saihesteko. Parametroa 0.5eko gehienezko baliora eramateak babes osoa eskaintzen du. Hala ere, balio hau murrizteak babes-maila jaitsi dezake, indexazio-efektua arindu dezakeen bitartean.",
+    "Sample Rate": "Lagin-tasa",
     "Sampling Rate": "Laginketa-tasa",
     "Save Every Epoch": "Gorde Epoka Bakoitzean",
     "Save Every Weights": "Gorde Pisu Guztiak",
@@ -326,6 +326,7 @@
     "Start": "Hasi",
     "Start Training": "Hasi Entrenamendua",
     "Status": "Egoera",
+    "Stereo": "Estereo",
     "Stop": "Gelditu",
     "Stop Training": "Gelditu Entrenamendua",
     "Stop convert": "Gelditu bihurketa",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Bolumen-maila honen azpitik, audioa isiltasuntzat hartzen da eta ez da prozesatzen. CPU baliabideak aurrezten eta atzeko zarata murrizten laguntzen du.",
     "Warming up... ({} blocks remaining)": "Berotzen... ({} bloke geratzen dira)",
     "You can also use a custom path.": "Bide pertsonalizatu bat ere erabil dezakezu.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Laguntza](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Laguntza](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Audio irteera-fluxurako erabiltzen den lagin-tasa. Gainidatzi hau gidaria tasa okerra jakinarazten badu (adib. 44100 Hz-ren ordez 48000 Hz)."
 }

--- a/assets/i18n/languages/fa_FA.json
+++ b/assets/i18n/languages/fa_FA.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "فایل plugin.zip خود را برای نصب اینجا بکشید",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "مدت زمان محوشدگی بین قطعات صوتی برای جلوگیری از کلیک. مقادیر بالاتر انتقال‌های نرم‌تری ایجاد می‌کنند اما ممکن است تأخیر را افزایش دهند.",
     "Embedder Model": "مدل جاسازی‌کننده",
+    "Enable ASIO": "فعال کردن ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "فعال کردن پشتیبانی درایور ASIO. (نیاز به راه‌اندازی مجدد Applio دارد)",
     "Enable Applio integration with Discord presence": "فعال‌سازی یکپارچه‌سازی Applio با وضعیت دیسکورد",
     "Enable VAD": "فعال‌سازی VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "فعال‌سازی تغییر فرمانت. برای تبدیل‌های مرد به زن و بالعکس استفاده می‌شود.",
@@ -134,9 +136,6 @@
     "File to Speech": "فایل به گفتار",
     "Filter": "فیلتر",
     "Folder Name": "نام پوشه",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "برای درایورهای ASIO، یک کانال ورودی خاص را انتخاب می‌کند. برای حالت پیش‌فرض، روی -1 باقی بگذارید.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "برای درایورهای ASIO، یک کانال خروجی مانیتور خاص را انتخاب می‌کند. برای حالت پیش‌فرض، روی -1 باقی بگذارید.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "برای درایورهای ASIO، یک کانال خروجی خاص را انتخاب می‌کند. برای حالت پیش‌فرض، روی -1 باقی بگذارید.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "برای WASAPI (ویندوز)، کنترل انحصاری را برای تأخیر بالقوه کمتر به برنامه می‌دهد.",
     "Formant Shifting": "تغییر فرمانت",
     "Fresh Training": "آموزش از نو",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "گین مرطوب ریورب",
     "Reverb Width": "عرض ریورب",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "از همخوان‌های متمایز و صداهای تنفس برای جلوگیری از پارگی الکترو-آکوستیک و سایر آرتیفکت‌ها محافظت کنید. کشیدن پارامتر به حداکثر مقدار خود یعنی ۰.۵، حفاظت جامعی را ارائه می‌دهد. با این حال، کاهش این مقدار ممکن است میزان حفاظت را کاهش دهد در حالی که به طور بالقوه اثر ایندکس‌گذاری را کاهش می‌دهد.",
+    "Sample Rate": "نرخ نمونه‌برداری",
     "Sampling Rate": "نرخ نمونه‌برداری",
     "Save Every Epoch": "ذخیره در هر ایپاک",
     "Save Every Weights": "ذخیره تمام وزن‌ها",
@@ -326,6 +326,7 @@
     "Start": "شروع",
     "Start Training": "شروع آموزش",
     "Status": "وضعیت",
+    "Stereo": "استریو",
     "Stop": "توقف",
     "Stop Training": "توقف آموزش",
     "Stop convert": "توقف تبدیل",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "سطح صدایی که پایین‌تر از آن، صوت به عنوان سکوت در نظر گرفته شده و پردازش نمی‌شود. به صرفه‌جویی در منابع CPU و کاهش نویز پس‌زمینه کمک می‌کند.",
     "Warming up... ({} blocks remaining)": "گرم کردن... ({} بلاک باقی‌مانده)",
     "You can also use a custom path.": "شما همچنین می‌توانید از یک مسیر سفارشی استفاده کنید.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[پشتیبانی](https://discord.gg/urxFjYmYYh) — [گیت‌هاب](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[پشتیبانی](https://discord.gg/urxFjYmYYh) — [گیت‌هاب](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "نرخ نمونه‌برداری که برای پخش صوت استفاده می‌شود. اگر درایور نرخ نادرستی گزارش می‌دهد این را تغییر دهید (مثلاً 48000 هرتز به جای 44100 هرتز)."
 }

--- a/assets/i18n/languages/fj_FJ.json
+++ b/assets/i18n/languages/fj_FJ.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Yaroca na nomu plugin.zip mo vakacuruma",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Na balavu ni gauna ni veisau malumu ena maliwa ni tiki ni rorogo me tarova na rorogo vakatotolo ('clicks'). Na i wiliwili lelevu e bulia na veisau malumu ia e rawa ni vakalevutaka na berabera.",
     "Embedder Model": "iVakarau ni iVakacurumi",
+    "Enable ASIO": "Vakayagataka ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Vakayagataka na veivukei ni ASIO driver. (E gadrevi me tekivutaki tale na Applio)",
     "Enable Applio integration with Discord presence": "Vakabula na semati ni Applio kei na tiko ni Discord",
     "Enable VAD": "Vakabula na VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Vakabula na veisau ni formant. E vakayagataki me baleta na veisau mai na tagane ki na yalewa kei na kena veibasai.",
@@ -134,9 +136,6 @@
     "File to Speech": "Faile ki na Vosa",
     "Filter": "Filter",
     "Folder Name": "Yaca ni iLalawa",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Vei ira na draiva ni ASIO, e digitaka e dua na sala vakatabakidua ni ka e curu mai. Biuta tu ena -1 me baleta na kena i tuvaki taumada.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Vei ira na draiva ni ASIO, e digitaka e dua na sala vakatabakidua ni ka e curu yani me vakarorogotaki. Biuta tu ena -1 me baleta na kena i tuvaki taumada.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Vei ira na draiva ni ASIO, e digitaka e dua na sala vakatabakidua ni ka e curu yani. Biuta tu ena -1 me baleta na kena i tuvaki taumada.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Me baleta na WASAPI (Windows), e solia ki na 'app' na lewa vakatabakidua me rawa ni lailai sobu kina na berabera.",
     "Formant Shifting": "Veisau ni Formant",
     "Fresh Training": "Vuli Vou",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Gain Suasua ni Reverb",
     "Reverb Width": "Raba ni Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Taqlomaka na vosa duidui kei na rorogo ni icegu me tarova na dresulaki ni rorogo kei na veicala tale eso. Na kena tosoi na ivakarau ki na kena iwiliwili cecere duadua e 0.5 e solia na veitaqomaki taucoko. Ia, na vakalailaitaki ni iwiliwili oqo e rawa ni vakalailaitaka na veitaqomaki ka rawa ni vakalailaitaka talega na revurevu ni vakadikevi.",
+    "Sample Rate": "Reiti ni Ivakatokai",
     "Sampling Rate": "iWiliwili ni Vakatovotovo",
     "Save Every Epoch": "Maroroya na Veigauna Kece",
     "Save Every Weights": "Maroroya na Veibibi Kece",
@@ -326,6 +326,7 @@
     "Start": "Tekivu",
     "Start Training": "Tekivu na Vuli",
     "Status": "iTuvaki",
+    "Stereo": "Stereo",
     "Stop": "Cegu",
     "Stop Training": "Vakacegu na Vuli",
     "Stop convert": "Vakacegu na veisau",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Na i vakatagedegede ni rorogo e lailai sobu mai kina e okati na rorogo me galu ka sega ni cakacakataki. E vukea me maroroi na kaukauwa ni CPU ka vakalailaitaka na rorogo e muri.",
     "Warming up... ({} blocks remaining)": "E vakarautaki... ({} na ivolau e tiko ga)",
     "You can also use a custom path.": "E rawa talega ni ko vakayagataka e dua na sala vakayagataki.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Veitokoni](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Veitokoni](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Reiti ni ivakatokai e vakayagataki me na audio streaming. Vakacava oqo me vakacaucautaka na reiti e tukuna na driver (e.g. 48000 Hz e sega ni 44100 Hz)."
 }

--- a/assets/i18n/languages/fr_FR.json
+++ b/assets/i18n/languages/fr_FR.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Glissez votre plugin.zip pour l'installer",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Durée du fondu entre les blocs audio pour éviter les clics. Des valeurs plus élevées créent des transitions plus douces mais peuvent augmenter la latence.",
     "Embedder Model": "Modèle d'intégration",
+    "Enable ASIO": "Activer ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Activer le support du pilote ASIO. (Redémarrage d'Applio requis)",
     "Enable Applio integration with Discord presence": "Activer l'intégration d'Applio avec la présence Discord",
     "Enable VAD": "Activer la VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Activer le décalage des formants. Utilisé pour les conversions de voix d'homme à femme et vice-versa.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fichier vers parole",
     "Filter": "Filtre",
     "Folder Name": "Nom du dossier",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Pour les pilotes ASIO, sélectionne un canal d'entrée spécifique. Laissez à -1 pour la valeur par défaut.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Pour les pilotes ASIO, sélectionne un canal de sortie pour le retour audio. Laissez à -1 pour la valeur par défaut.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Pour les pilotes ASIO, sélectionne un canal de sortie spécifique. Laissez à -1 pour la valeur par défaut.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Pour WASAPI (Windows), donne à l'application un contrôle exclusif pour une latence potentiellement plus faible.",
     "Formant Shifting": "Décalage des formants",
     "Fresh Training": "Nouvel entraînement",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Gain humide de la réverbération",
     "Reverb Width": "Largeur de la réverbération",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Protégez les consonnes distinctes et les bruits de respiration pour éviter les déchirements électro-acoustiques et autres artefacts. Pousser le paramètre à sa valeur maximale de 0.5 offre une protection complète. Cependant, réduire cette valeur peut diminuer le niveau de protection tout en atténuant potentiellement l'effet d'indexation.",
+    "Sample Rate": "Fréquence d'échantillonnage",
     "Sampling Rate": "Fréquence d'échantillonnage",
     "Save Every Epoch": "Sauvegarder à chaque époque",
     "Save Every Weights": "Sauvegarder tous les poids",
@@ -326,6 +326,7 @@
     "Start": "Démarrer",
     "Start Training": "Démarrer l'entraînement",
     "Status": "Statut",
+    "Stereo": "Stéréo",
     "Stop": "Arrêter",
     "Stop Training": "Arrêter l'entraînement",
     "Stop convert": "Arrêter la conversion",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Niveau de volume en dessous duquel l'audio est considéré comme du silence et n'est pas traité. Aide à économiser les ressources CPU et à réduire le bruit de fond.",
     "Warming up... ({} blocks remaining)": "Préchauffage... ({} blocs restants)",
     "You can also use a custom path.": "Vous pouvez également utiliser un chemin personnalisé.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Fréquence d'échantillonnage utilisée pour le flux audio. Remplacez ceci si le pilote signale une fréquence incorrecte (p. ex. 48000 Hz au lieu de 44100 Hz)."
 }

--- a/assets/i18n/languages/ga_GA.json
+++ b/assets/i18n/languages/ga_GA.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Tarraing do plugin.zip chun é a shuiteáil",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Fad an chéimnithe idir smutaí fuaime chun cliceanna a chosc. Cruthaíonn luachanna níos airde aistrithe níos míne ach d'fhéadfadh siad an t-aga folaigh a mhéadú.",
     "Embedder Model": "Múnla Leabaitheora",
+    "Enable ASIO": "Cumasaigh ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Cumasaigh tacaíocht tiománaí ASIO. (Éilíonn sé Applio a atosú)",
     "Enable Applio integration with Discord presence": "Cumasaigh comhtháthú Applio le láithreacht Discord",
     "Enable VAD": "Cumasaigh VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Cumasaigh aistriú formant. Úsáidtear é do chomhshóite ó fhireann go baineann agus a mhalairt.",
@@ -134,9 +136,6 @@
     "File to Speech": "Comhad go Caint",
     "Filter": "Scagaire",
     "Folder Name": "Ainm an Fhillteáin",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "I gcás tiománaithe ASIO, roghnaíonn sé cainéal ionchuir ar leith. Fág ag -1 don réamhshocrú.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "I gcás tiománaithe ASIO, roghnaíonn sé cainéal aschuir monatóireachta ar leith. Fág ag -1 don réamhshocrú.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "I gcás tiománaithe ASIO, roghnaíonn sé cainéal aschuir ar leith. Fág ag -1 don réamhshocrú.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "I gcás WASAPI (Windows), tugann sé smacht eisiach don aip le haghaidh aga folaigh a d'fhéadfadh a bheith níos ísle.",
     "Formant Shifting": "Aistriú Formant",
     "Fresh Training": "Traenáil Úrnua",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Gnóthachan Fliuch an Aisfhuaimnithe",
     "Reverb Width": "Leithead an Aisfhuaimnithe",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Cosain consain ar leith agus fuaimeanna anála chun cuimilt leictrea-fhuaimiúil agus déantáin eile a chosc. Tugann an paraiméadar a tharraingt chuig a uasluach de 0.5 cosaint chuimsitheach. Mar sin féin, d'fhéadfadh laghdú an luacha seo méid na cosanta a laghdú agus an éifeacht innéacsaithe a mhaolú b'fhéidir.",
+    "Sample Rate": "Ráta Samplála",
     "Sampling Rate": "Ráta Samplála",
     "Save Every Epoch": "Sábháil Gach Eapach",
     "Save Every Weights": "Sábháil Gach Meáchan",
@@ -326,6 +326,7 @@
     "Start": "Tosaigh",
     "Start Training": "Cuir tús leis an Traenáil",
     "Status": "Stádas",
+    "Stereo": "Steirió",
     "Stop": "Stad",
     "Stop Training": "Stop an Traenáil",
     "Stop convert": "Stop an comhshó",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "An leibhéal toirte faoina ndéileáiltear le fuaim mar thost agus nach bpróiseáiltear í. Cuidíonn sé seo le hacmhainní CPU a shábháil agus le torann cúlra a laghdú.",
     "Warming up... ({} blocks remaining)": "Ag téamh suas... ({} bloc fágtha)",
     "You can also use a custom path.": "Is féidir leat cosán saincheaptha a úsáid freisin.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Tacaíocht](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Tacaíocht](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Ráta samplála a úsáidtear le haghaidh sruthú fuaime. Sáraigh é seo má thuairiscíonn an tiománaí ráta mícheart (m.sh. 48000 Hz in ionad 44100 Hz)."
 }

--- a/assets/i18n/languages/gu_GU.json
+++ b/assets/i18n/languages/gu_GU.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "ઇન્સ્ટોલ કરવા માટે તમારું plugin.zip ખેંચો",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "ક્લિક્સને રોકવા માટે ઓડિયો ચંક્સ વચ્ચેના ફેડનો સમયગાળો. ઊંચા મૂલ્યો સરળ સંક્રમણ બનાવે છે પરંતુ લેટન્સી વધારી શકે છે.",
     "Embedder Model": "એમ્બેડર મોડેલ",
+    "Enable ASIO": "ASIO સક્ષમ કરો",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO ડ્રાઇવર સપોર્ટ સક્ષમ કરો. (Applio પુનઃપ્રારંભ કરવાની જરૂર છે)",
     "Enable Applio integration with Discord presence": "Discord પ્રેઝન્સ સાથે Applio એકીકરણ સક્ષમ કરો",
     "Enable VAD": "VAD સક્ષમ કરો",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "ફોર્મેન્ટ શિફ્ટિંગ સક્ષમ કરો. પુરુષથી સ્ત્રી અને ઊલટું રૂપાંતરણ માટે વપરાય છે.",
@@ -134,9 +136,6 @@
     "File to Speech": "ફાઇલ ટુ સ્પીચ",
     "Filter": "ફિલ્ટર",
     "Folder Name": "ફોલ્ડરનું નામ",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO ડ્રાઇવરો માટે, એક વિશિષ્ટ ઇનપુટ ચેનલ પસંદ કરે છે. ડિફોલ્ટ માટે -1 પર રાખો.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO ડ્રાઇવરો માટે, એક વિશિષ્ટ મોનિટર આઉટપુટ ચેનલ પસંદ કરે છે. ડિફોલ્ટ માટે -1 પર રાખો.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO ડ્રાઇવરો માટે, એક વિશિષ્ટ આઉટપુટ ચેનલ પસંદ કરે છે. ડિફોલ્ટ માટે -1 પર રાખો.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) માટે, સંભવિતપણે ઓછી લેટન્સી માટે એપ્લિકેશનને વિશિષ્ટ નિયંત્રણ આપે છે.",
     "Formant Shifting": "ફોર્મેન્ટ શિફ્ટિંગ",
     "Fresh Training": "ફ્રેશ ટ્રેનિંગ",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "રિવર્બ વેટ ગેઇન",
     "Reverb Width": "રિવર્બ વિડ્થ",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "ઇલેક્ટ્રો-એકોસ્ટિક ટિયરિંગ અને અન્ય આર્ટિફેક્ટ્સને રોકવા માટે વિશિષ્ટ વ્યંજનો અને શ્વાસના અવાજોનું રક્ષણ કરો. પેરામીટરને તેના મહત્તમ મૂલ્ય 0.5 પર ખેંચવાથી વ્યાપક સુરક્ષા મળે છે. જો કે, આ મૂલ્ય ઘટાડવાથી સુરક્ષાની હદ ઘટી શકે છે જ્યારે સંભવિતપણે ઇન્ડેક્સિંગ અસરને ઘટાડી શકે છે.",
+    "Sample Rate": "સેમ્પલ રેટ",
     "Sampling Rate": "સેમ્પલિંગ રેટ",
     "Save Every Epoch": "દરેક યુગ સાચવો",
     "Save Every Weights": "દરેક વજન સાચવો",
@@ -326,6 +326,7 @@
     "Start": "શરૂ કરો",
     "Start Training": "તાલીમ શરૂ કરો",
     "Status": "સ્થિતિ",
+    "Stereo": "સ્ટીરિઓ",
     "Stop": "બંધ કરો",
     "Stop Training": "તાલીમ બંધ કરો",
     "Stop convert": "રૂપાંતરણ રોકો",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "વોલ્યુમનું સ્તર જેના નીચે ઓડિયોને મૌન તરીકે ગણવામાં આવે છે અને તેના પર પ્રક્રિયા થતી નથી. CPU સંસાધનો બચાવવા અને પૃષ્ઠભૂમિ ઘોંઘાટ ઘટાડવામાં મદદ કરે છે.",
     "Warming up... ({} blocks remaining)": "વોર્મિંગ અપ... ({} બ્લોક બાકી)",
     "You can also use a custom path.": "તમે કસ્ટમ પાથનો પણ ઉપયોગ કરી શકો છો.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[સપોર્ટ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[સપોર્ટ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "ઓડિઓ સ્ટ્રીમિંગ માટે ઉપયોગ કરવામાં આવતો સેમ્પલ રેટ. ડ્રાઇવર ખોટો રેટ દર્શાવે તો આ ઓવરરાઇડ કરો (દા.ત. 44100 Hz ને બદલે 48000 Hz)."
 }

--- a/assets/i18n/languages/he_HE.json
+++ b/assets/i18n/languages/he_HE.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "גררו את קובץ ה-plugin.zip שלכם כדי להתקין אותו",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "משך המעבר (fade) בין נתחי שמע למניעת קליקים. ערכים גבוהים יותר יוצרים מעברים חלקים יותר אך עלולים להגביר את ההשהיה (latency).",
     "Embedder Model": "מודל Embedder",
+    "Enable ASIO": "הפעל ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "הפעל תמיכה במנהל התקן ASIO. (דורש הפעלה מחדש של Applio)",
     "Enable Applio integration with Discord presence": "הפעל אינטגרציה של Applio עם נוכחות Discord",
     "Enable VAD": "הפעל זיהוי פעילות קולית (VAD)",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "הפעל הזזת פורמנטים (formant shifting). משמש להמרות מזכר לנקבה ולהיפך.",
@@ -134,9 +136,6 @@
     "File to Speech": "קובץ לדיבור",
     "Filter": "מסנן",
     "Folder Name": "שם תיקייה",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "עבור מנהלי התקן של ASIO, בוחר ערוץ כניסה ספציפי. יש להשאיר על -1 לברירת המחדל.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "עבור מנהלי התקן של ASIO, בוחר ערוץ יציאת ניטור ספציפי. יש להשאיר על -1 לברירת המחדל.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "עבור מנהלי התקן של ASIO, בוחר ערוץ יציאה ספציפי. יש להשאיר על -1 לברירת המחדל.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "עבור WASAPI (Windows), מעניק לאפליקציה שליטה בלעדית להשהיה (latency) נמוכה יותר באופן פוטנציאלי.",
     "Formant Shifting": "הזזת פורמנטים",
     "Fresh Training": "אימון חדש",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "עוצמה רטובה (Wet) של Reverb",
     "Reverb Width": "רוחב Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "שמירה על עיצורים ברורים וצלילי נשימה כדי למנוע קריעה אלקטרו-אקוסטית וארטיפקטים אחרים. משיכת הפרמטר לערכו המרבי של 0.5 מציעה הגנה מקיפה. עם זאת, הקטנת ערך זה עשויה להפחית את רמת ההגנה תוך הפחתה פוטנציאלית של אפקט האינדוקס.",
+    "Sample Rate": "קצב דגימה",
     "Sampling Rate": "קצב דגימה",
     "Save Every Epoch": "שמור כל איפוק",
     "Save Every Weights": "שמור את כל המשקלים",
@@ -326,6 +326,7 @@
     "Start": "התחל",
     "Start Training": "התחל אימון",
     "Status": "מצב",
+    "Stereo": "סטריאו",
     "Stop": "עצור",
     "Stop Training": "עצור אימון",
     "Stop convert": "עצור המרה",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "עוצמת קול שמתחתיה השמע יטופל כשקט ולא יעובד. מסייע לחסוך במשאבי מעבד (CPU) ולהפחית רעשי רקע.",
     "Warming up... ({} blocks remaining)": "מתחמם... ({} בלוקים נותרו)",
     "You can also use a custom path.": "ניתן גם להשתמש בנתיב מותאם אישית.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[תמיכה](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[תמיכה](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "קצב הדגימה המשמש להזרמת שמע. עקוף זאת אם מנהל ההתקן מדווח על קצב שגוי (למשל 48000 הרץ במקום 44100 הרץ)."
 }

--- a/assets/i18n/languages/hi_IN.json
+++ b/assets/i18n/languages/hi_IN.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "इसे स्थापित करने के लिए अपना plugin.zip खींचें",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "क्लिक्स को रोकने के लिए ऑडियो चंक्स के बीच फ़ेड की अवधि। उच्च मान सहज संक्रमण बनाते हैं लेकिन लेटेंसी बढ़ा सकते हैं।",
     "Embedder Model": "एम्बेडर मॉडल",
+    "Enable ASIO": "ASIO सक्षम करें",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO ड्राइवर समर्थन सक्षम करें। ASIO डिवाइस को इनपुट/आउटपुट के रूप में चुनें और ऊपर चैनल नंबर सेट करें। परिवर्तन प्रभावी होने के लिए Applio को पुनः प्रारंभ करना आवश्यक है।(Applio को पुनरारंभ करने की आवश्यकता है)",
     "Enable Applio integration with Discord presence": "Discord उपस्थिति के साथ Applio एकीकरण सक्षम करें",
     "Enable VAD": "VAD सक्षम करें",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "फोर्मेंट शिफ्टिंग सक्षम करें। पुरुष से महिला और इसके विपरीत रूपांतरणों के लिए उपयोग किया जाता है।",
@@ -134,9 +136,6 @@
     "File to Speech": "फ़ाइल से स्पीच",
     "Filter": "फ़िल्टर",
     "Folder Name": "फ़ोल्डर का नाम",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO ड्राइवरों के लिए, एक विशिष्ट इनपुट चैनल चुनता है। डिफ़ॉल्ट के लिए -1 पर छोड़ दें।",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO ड्राइवरों के लिए, एक विशिष्ट मॉनिटर आउटपुट चैनल चुनता है। डिफ़ॉल्ट के लिए -1 पर छोड़ दें।",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO ड्राइवरों के लिए, एक विशिष्ट आउटपुट चैनल चुनता है। डिफ़ॉल्ट के लिए -1 पर छोड़ दें।",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) के लिए, संभावित रूप से कम लेटेंसी के लिए ऐप को विशेष नियंत्रण देता है।",
     "Formant Shifting": "फोर्मेंट शिफ्टिंग",
     "Fresh Training": "नया प्रशिक्षण",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "रिवर्ब वेट गेन",
     "Reverb Width": "रिवर्ब विड्थ",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "इलेक्ट्रो-अकॉस्टिक टियरिंग और अन्य आर्टिफैक्ट्स को रोकने के लिए विशिष्ट व्यंजनों और सांस लेने की ध्वनियों को सुरक्षित रखें। पैरामीटर को इसके अधिकतम मान 0.5 तक ले जाना व्यापक सुरक्षा प्रदान करता है। हालांकि, इस मान को कम करने से सुरक्षा की सीमा कम हो सकती है, जबकि इंडेक्सिंग प्रभाव को संभावित रूप से कम किया जा सकता है।",
+    "Sample Rate": "सैम्पल रेट",
     "Sampling Rate": "सैंपलिंग दर",
     "Save Every Epoch": "हर एपॉक सहेजें",
     "Save Every Weights": "हर वेट सहेजें",
@@ -326,6 +326,7 @@
     "Start": "शुरू करें",
     "Start Training": "प्रशिक्षण शुरू करें",
     "Status": "स्टेटस",
+    "Stereo": "स्टीरियो",
     "Stop": "रोकें",
     "Stop Training": "प्रशिक्षण रोकें",
     "Stop convert": "रूपांतरण रोकें",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "वॉल्यूम का वह स्तर जिसके नीचे ऑडियो को मौन माना जाता है और संसाधित नहीं किया जाता है। CPU संसाधनों को बचाने और पृष्ठभूमि के शोर को कम करने में मदद करता है।",
     "Warming up... ({} blocks remaining)": "वार्मिंग अप... ({} ब्लॉक शेष)",
     "You can also use a custom path.": "आप एक कस्टम पथ का भी उपयोग कर सकते हैं।",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[समर्थन](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[समर्थन](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "ऑडियो स्ट्रीमिंग के लिए उपयोग किया जाने वाला सैम्पल रेट। यदि ड्राइवर गलत रेट रिपोर्ट करे तो इसे बदलें (जैसे 44100 Hz की जगह 48000 Hz)।"
 }

--- a/assets/i18n/languages/hr_HR.json
+++ b/assets/i18n/languages/hr_HR.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Povucite svoj plugin.zip da ga instalirate",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Trajanje pretapanja između audio isječaka radi sprječavanja pucketanja. Više vrijednosti stvaraju glađe prijelaze, ali mogu povećati latenciju.",
     "Embedder Model": "Model embeddera",
+    "Enable ASIO": "Omogući ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Omogući podršku za ASIO upravljački program. (Zahtijeva ponovno pokretanje Applia)",
     "Enable Applio integration with Discord presence": "Omogući integraciju Applia s Discord statusom",
     "Enable VAD": "Omogući VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Omogući pomicanje formanata. Koristi se za konverzije s muškog na ženski glas i obrnuto.",
@@ -134,9 +136,6 @@
     "File to Speech": "Datoteka u govor",
     "Filter": "Filtar",
     "Folder Name": "Naziv mape",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Za ASIO drivere, odabire određeni ulazni kanal. Ostavite -1 za zadano.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Za ASIO drivere, odabire određeni izlazni kanal za praćenje (monitor). Ostavite -1 za zadano.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Za ASIO drivere, odabire određeni izlazni kanal. Ostavite -1 za zadano.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Za WASAPI (Windows), daje aplikaciji ekskluzivnu kontrolu za potencijalno nižu latenciju.",
     "Formant Shifting": "Pomicanje formanata",
     "Fresh Training": "Novo treniranje",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Mokro pojačanje jeke",
     "Reverb Width": "Širina jeke",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Zaštitite izražene suglasnike i zvukove disanja kako biste spriječili elektroakustičko kidanje i druge artefakte. Postavljanje parametra na maksimalnu vrijednost od 0.5 nudi sveobuhvatnu zaštitu. Međutim, smanjenje ove vrijednosti može smanjiti opseg zaštite, ali potencijalno ublažiti efekt indeksiranja.",
+    "Sample Rate": "Frekvencija uzorkovanja",
     "Sampling Rate": "Brzina uzorkovanja",
     "Save Every Epoch": "Spremi svaku epohu",
     "Save Every Weights": "Spremi sve težine",
@@ -326,6 +326,7 @@
     "Start": "Pokreni",
     "Start Training": "Započni treniranje",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Zaustavi",
     "Stop Training": "Zaustavi treniranje",
     "Stop convert": "Zaustavi pretvorbu",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Razina glasnoće ispod koje se zvuk tretira kao tišina i ne obrađuje. Pomaže u uštedi CPU resursa i smanjenju pozadinske buke.",
     "Warming up... ({} blocks remaining)": "Zagrijavanje... (preostalo {} blokova)",
     "You can also use a custom path.": "Možete koristiti i prilagođenu putanju.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podrška](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podrška](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Frekvencija uzorkovanja koja se koristi za audio prijenos. Zamijeni ovo ako upravljački program prijavi netočnu frekvenciju (npr. 48000 Hz umjesto 44100 Hz)."
 }

--- a/assets/i18n/languages/ht_HT.json
+++ b/assets/i18n/languages/ht_HT.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Glise plugin.zip ou a pou enstale li",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Dire tranzisyon ant moso odyo yo pou anpeche klik. Valè ki pi wo yo kreye tranzisyon pi dous men yo ka ogmante latans.",
     "Embedder Model": "Modèl Enkòporatè",
+    "Enable ASIO": "Aktive ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Aktive sipò chofè ASIO. (Mande pou redemare Applio)",
     "Enable Applio integration with Discord presence": "Aktive entegrasyon Applio ak prezans Discord",
     "Enable VAD": "Aktive VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Aktive chanjman fòmant. Itilize pou konvèsyon gason an fi ak vis vèsa.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fichye an Pawòl",
     "Filter": "Filtè",
     "Folder Name": "Non Dosye",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Pou pilòt ASIO, chwazi yon kanal antre espesifik. Kite l sou -1 pou valè pa defo.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Pou pilòt ASIO, chwazi yon kanal sòti monitè espesifik. Kite l sou -1 pou valè pa defo.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Pou pilòt ASIO, chwazi yon kanal sòti espesifik. Kite l sou -1 pou valè pa defo.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Pou WASAPI (Windows), bay aplikasyon an kontwòl eksklizif pou potansyèlman diminye latans.",
     "Formant Shifting": "Chanjman Fòmant",
     "Fresh Training": "Fòmasyon Depi Zero",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Gain Mouye Reverb",
     "Reverb Width": "Lajè Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Pwoteje konsòn distenk ak son respirasyon pou anpeche dechiri elektwo-akoustik ak lòt artefak. Mete paramèt la nan valè maksimòm li ki se 0.5 ofri yon pwoteksyon konplè. Sepandan, diminye valè sa a ka diminye nivo pwoteksyon an pandan l ap potansyèlman diminye efè endèksasyon an.",
+    "Sample Rate": "Vitès echantiyonaj",
     "Sampling Rate": "To Echantiyonaj",
     "Save Every Epoch": "Sove Chak Epòk",
     "Save Every Weights": "Sove Chak Pwa",
@@ -326,6 +326,7 @@
     "Start": "Kòmanse",
     "Start Training": "Kòmanse Fòmasyon",
     "Status": "Estati",
+    "Stereo": "Esteywo",
     "Stop": "Sispann",
     "Stop Training": "Sispann Fòmasyon",
     "Stop convert": "Sispann konvèsyon",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Nivo volim kote odyo a konsidere kòm silans epi li pa trete. Sa ede ekonomize resous CPU epi redwi bri anbyan.",
     "Warming up... ({} blocks remaining)": "Ap chofe... ({} blòk ki rete)",
     "You can also use a custom path.": "Ou ka itilize yon chemen pèsonalize tou.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Sipò](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Sipò](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Vitès echantiyonaj ki itilize pou difizyon odyo. Ranplase sa a si chofè rapòte yon vitès enkòrèk (pa egz. 48000 Hz olye 44100 Hz)."
 }

--- a/assets/i18n/languages/hu_HU.json
+++ b/assets/i18n/languages/hu_HU.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Húzza ide a plugin.zip fájlt a telepítéshez",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Az audio darabok közötti áttűnés időtartama a kattanások elkerülése érdekében. A magasabb értékek simább átmeneteket eredményeznek, de növelhetik a késleltetést.",
     "Embedder Model": "Beágyazó (Embedder) modell",
+    "Enable ASIO": "ASIO engedélyezése",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO illesztőprogram-támogatás engedélyezése. (Az Applio újraindítása szükséges)",
     "Enable Applio integration with Discord presence": "Applio integráció engedélyezése a Discord jelenléttel",
     "Enable VAD": "VAD engedélyezése",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Formáns-eltolás engedélyezése. Férfi-nő és nő-férfi hangátalakításokhoz használatos.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fájlból beszéd",
     "Filter": "Szűrő",
     "Folder Name": "Mappa neve",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO meghajtók esetén egy adott bemeneti csatornát választ ki. Hagyja -1-en az alapértelmezett beállításhoz.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO meghajtók esetén egy adott monitor kimeneti csatornát választ ki. Hagyja -1-en az alapértelmezett beállításhoz.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO meghajtók esetén egy adott kimeneti csatornát választ ki. Hagyja -1-en az alapértelmezett beállításhoz.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) esetén kizárólagos vezérlést biztosít az alkalmazásnak a potenciálisan alacsonyabb késleltetés érdekében.",
     "Formant Shifting": "Formáns-eltolás",
     "Fresh Training": "Új tanítás",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Zengés nedves erősítés",
     "Reverb Width": "Zengés szélesség",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Védje a megkülönböztethető mássalhangzókat és légzési hangokat az elektroakusztikus szakadás és egyéb műtermékek megelőzése érdekében. A paraméter 0.5 maximális értékre húzása átfogó védelmet nyújt. Ennek az értéknek a csökkentése azonban csökkentheti a védelem mértékét, miközben potenciálisan enyhítheti az indexelési hatást.",
+    "Sample Rate": "Mintavételi frekvencia",
     "Sampling Rate": "Mintavételezési frekvencia",
     "Save Every Epoch": "Mentés minden epoch után",
     "Save Every Weights": "Minden súly mentése",
@@ -326,6 +326,7 @@
     "Start": "Indítás",
     "Start Training": "Tanítás indítása",
     "Status": "Állapot",
+    "Stereo": "Sztereó",
     "Stop": "Leállítás",
     "Stop Training": "Tanítás leállítása",
     "Stop convert": "Átalakítás leállítása",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Az a hangerőszint, amely alatt a hang csendnek minősül és nem kerül feldolgozásra. Segít a CPU-erőforrások megtakarításában és a háttérzaj csökkentésében.",
     "Warming up... ({} blocks remaining)": "Bemelegítés... ({} blokk hátravan)",
     "You can also use a custom path.": "Használhat egyéni útvonalat is.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Támogatás](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Támogatás](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Az audio streameléshez használt mintavételi frekvencia. Felülírja ezt, ha az illesztőprogram helytelen frekvenciát jelez (pl. 44100 Hz helyett 48000 Hz)."
 }

--- a/assets/i18n/languages/id_ID.json
+++ b/assets/i18n/languages/id_ID.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Seret plugin.zip Anda untuk menginstalnya",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Durasi fade di antara potongan audio untuk mencegah bunyi klik. Nilai yang lebih tinggi menciptakan transisi yang lebih halus tetapi dapat meningkatkan latensi.",
     "Embedder Model": "Model Embedder",
+    "Enable ASIO": "Aktifkan ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Aktifkan dukungan driver ASIO. (Memerlukan memulai ulang Applio)",
     "Enable Applio integration with Discord presence": "Aktifkan integrasi Applio dengan kehadiran Discord",
     "Enable VAD": "Aktifkan VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Aktifkan pergeseran forman. Digunakan untuk konversi pria ke wanita dan sebaliknya.",
@@ -134,9 +136,6 @@
     "File to Speech": "File ke Ucapan",
     "Filter": "Filter",
     "Folder Name": "Nama Folder",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Untuk driver ASIO, memilih saluran input tertentu. Biarkan -1 untuk default.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Untuk driver ASIO, memilih saluran output monitor tertentu. Biarkan -1 untuk default.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Untuk driver ASIO, memilih saluran output tertentu. Biarkan -1 untuk default.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Untuk WASAPI (Windows), memberikan aplikasi kontrol eksklusif untuk potensi latensi yang lebih rendah.",
     "Formant Shifting": "Pergeseran Forman",
     "Fresh Training": "Pelatihan Baru",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Gain Basah Reverb",
     "Reverb Width": "Lebar Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Lindungi konsonan yang berbeda dan suara napas untuk mencegah robekan elektro-akustik dan artefak lainnya. Menarik parameter ke nilai maksimum 0.5 menawarkan perlindungan komprehensif. Namun, mengurangi nilai ini mungkin menurunkan tingkat perlindungan sambil berpotensi mengurangi efek pengindeksan.",
+    "Sample Rate": "Laju Sampel",
     "Sampling Rate": "Laju Sampel",
     "Save Every Epoch": "Simpan Setiap Epoch",
     "Save Every Weights": "Simpan Setiap Bobot",
@@ -326,6 +326,7 @@
     "Start": "Mulai",
     "Start Training": "Mulai Pelatihan",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Hentikan",
     "Stop Training": "Hentikan Pelatihan",
     "Stop convert": "Hentikan konversi",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Tingkat volume di mana audio dianggap hening dan tidak diproses. Membantu menghemat sumber daya CPU dan mengurangi kebisingan latar belakang.",
     "Warming up... ({} blocks remaining)": "Pemanasan... ({} blok tersisa)",
     "You can also use a custom path.": "Anda juga dapat menggunakan jalur kustom.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Dukungan](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Dukungan](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Laju sampel yang digunakan untuk streaming audio. Timpa ini jika driver melaporkan laju yang salah (mis. 48000 Hz bukan 44100 Hz)."
 }

--- a/assets/i18n/languages/it_IT.json
+++ b/assets/i18n/languages/it_IT.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Trascina il tuo plugin.zip per installarlo",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Durata della dissolvenza tra i chunk audio per prevenire i click. Valori più alti creano transizioni più fluide ma possono aumentare la latenza.",
     "Embedder Model": "Modello Embedder",
+    "Enable ASIO": "Abilita ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Abilita il supporto al driver ASIO. (Richiede il riavvio di Applio)",
     "Enable Applio integration with Discord presence": "Abilita l'integrazione di Applio con la presenza su Discord",
     "Enable VAD": "Abilita VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Abilita lo spostamento dei formanti (formant shifting). Usato per conversioni da maschile a femminile e viceversa.",
@@ -134,9 +136,6 @@
     "File to Speech": "File in Voce",
     "Filter": "Filtro",
     "Folder Name": "Nome Cartella",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Per i driver ASIO, seleziona un canale di ingresso specifico. Lasciare -1 per il valore predefinito.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Per i driver ASIO, seleziona un canale di uscita monitor specifico. Lasciare -1 per il valore predefinito.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Per i driver ASIO, seleziona un canale di uscita specifico. Lasciare -1 per il valore predefinito.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Per WASAPI (Windows), conferisce all'app il controllo esclusivo per una latenza potenzialmente inferiore.",
     "Formant Shifting": "Spostamento Formanti",
     "Fresh Training": "Addestramento da Zero",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Guadagno Wet Riverbero",
     "Reverb Width": "Larghezza Riverbero",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Salva le consonanti distinte e i suoni del respiro per prevenire tearing elettro-acustico e altri artefatti. Portare il parametro al suo valore massimo di 0.5 offre una protezione completa. Tuttavia, ridurre questo valore potrebbe diminuire il grado di protezione, mitigando potenzialmente l'effetto di indicizzazione.",
+    "Sample Rate": "Frequenza di campionamento",
     "Sampling Rate": "Frequenza di Campionamento",
     "Save Every Epoch": "Salva a Ogni Epoca",
     "Save Every Weights": "Salva Tutti i Pesi",
@@ -326,6 +326,7 @@
     "Start": "Avvia",
     "Start Training": "Avvia Addestramento",
     "Status": "Stato",
+    "Stereo": "Stereo",
     "Stop": "Ferma",
     "Stop Training": "Ferma Addestramento",
     "Stop convert": "Ferma conversione",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Livello di volume al di sotto del quale l'audio è considerato silenzio e non viene elaborato. Aiuta a risparmiare risorse della CPU e a ridurre il rumore di fondo.",
     "Warming up... ({} blocks remaining)": "Riscaldamento... ({} blocchi rimanenti)",
     "You can also use a custom path.": "Puoi anche usare un percorso personalizzato.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Supporto](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Supporto](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Frequenza di campionamento utilizzata per lo streaming audio. Sovrascrivila se il driver riporta una frequenza errata (es. 48000 Hz invece di 44100 Hz)."
 }

--- a/assets/i18n/languages/ja_JA.json
+++ b/assets/i18n/languages/ja_JA.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "plugin.zipをドラッグしてインストールします",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "クリックノイズを防ぐためのオーディオチャンク間のフェード時間。値を大きくするとトランジションが滑らかになりますが、遅延が増加する可能性があります。",
     "Embedder Model": "エンベッダーモデル",
+    "Enable ASIO": "ASIOを有効にする",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIOドライバーサポートを有効にします。（Applioの再起動が必要です）",
     "Enable Applio integration with Discord presence": "ApplioとDiscordのプレゼンス連携を有効にする",
     "Enable VAD": "VADを有効化",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "フォルマントシフトを有効にします。男性から女性、またはその逆の変換に使用されます。",
@@ -134,9 +136,6 @@
     "File to Speech": "ファイルから音声合成",
     "Filter": "フィルター",
     "Folder Name": "フォルダ名",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIOドライバーの場合、特定の入力チャンネルを選択します。デフォルトの場合は-1のままにしてください。",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIOドライバーの場合、特定のモニター出力チャンネルを選択します。デフォルトの場合は-1のままにしてください。",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIOドライバーの場合、特定の出力チャンネルを選択します。デフォルトの場合は-1のままにしてください。",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows)の場合、アプリに排他的な制御権を与え、潜在的な遅延を低減させます。",
     "Formant Shifting": "フォルマントシフト",
     "Fresh Training": "新規トレーニング",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "リバーブのウェットゲイン",
     "Reverb Width": "リバーブのウィドス",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "特徴的な子音や呼吸音を保護し、電気音響的な音割れやその他のアーティファクトを防ぎます。パラメータを最大値の0.5にすると、包括的な保護が得られます。ただし、この値を下げると保護の度合いが低下する可能性がありますが、インデックス効果を緩和できる場合があります。",
+    "Sample Rate": "サンプルレート",
     "Sampling Rate": "サンプリングレート",
     "Save Every Epoch": "エポックごとに保存",
     "Save Every Weights": "重みを毎エポック保存",
@@ -326,6 +326,7 @@
     "Start": "開始",
     "Start Training": "トレーニングを開始",
     "Status": "ステータス",
+    "Stereo": "ステレオ",
     "Stop": "停止",
     "Stop Training": "トレーニングを停止",
     "Stop convert": "変換を停止",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "この音量レベル以下の音声は無音として扱われ、処理されません。CPUリソースの節約とバックグラウンドノイズの低減に役立ちます。",
     "Warming up... ({} blocks remaining)": "ウォームアップ中... (残り {} ブロック)",
     "You can also use a custom path.": "カスタムパスを使用することもできます。",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[サポート](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[サポート](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "オーディオストリーミングに使用するサンプルレートです。ドライバーが誤った値を返すことがあるため、実際に設定されているサンプルレートを指定してください。"
 }

--- a/assets/i18n/languages/jv_JV.json
+++ b/assets/i18n/languages/jv_JV.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Seret plugin.zip sampeyan kanggo nginstal",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Durasi fade antarane potongan audio kanggo nyegah klik. Nilai sing luwih dhuwur nggawe transisi luwih alus nanging bisa nambah latensi.",
     "Embedder Model": "Model Embedder",
+    "Enable ASIO": "Aktifake ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Aktifake dhukungan driver ASIO. (Mbutuhake miwiti ulang Applio)",
     "Enable Applio integration with Discord presence": "Aktifake integrasi Applio karo kehadiran Discord",
     "Enable VAD": "Aktifake VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Aktifake pergeseran forman. Digunakake kanggo konversi lanang menyang wadon lan kosok balene.",
@@ -134,9 +136,6 @@
     "File to Speech": "File dadi Wicara",
     "Filter": "Filter",
     "Folder Name": "Jeneng Folder",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Kanggo driver ASIO, milih saluran input tartamtu. Jarke ing -1 kanggo gawan.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Kanggo driver ASIO, milih saluran output monitor tartamtu. Jarke ing -1 kanggo gawan.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Kanggo driver ASIO, milih saluran output tartamtu. Jarke ing -1 kanggo gawan.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Kanggo WASAPI (Windows), menehi aplikasi kontrol eksklusif kanggo latensi sing luwih cilik.",
     "Formant Shifting": "Pergeseran Formant",
     "Fresh Training": "Latihan Anyar",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Gain Basah Reverb",
     "Reverb Width": "Ambane Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Jaga konsonan sing beda lan swara ambegan kanggo nyegah sobek elektro-akustik lan artefak liyane. Narik parameter menyang nilai maksimal 0,5 menehi perlindungan sing komprehensif. Nanging, nyuda nilai iki bisa nyuda tingkat perlindungan nalika bisa nyuda efek indeksasi.",
+    "Sample Rate": "Tingkat Sampel",
     "Sampling Rate": "Tingkat Sampling",
     "Save Every Epoch": "Simpen Saben Epoch",
     "Save Every Weights": "Simpen Saben Bobot",
@@ -326,6 +326,7 @@
     "Start": "Miwiti",
     "Start Training": "Miwiti Latihan",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Mandheg",
     "Stop Training": "Manden Latihan",
     "Stop convert": "Manden konversi",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Tingkat volume ing ngendi audio dianggep sepi lan ora diproses. Mbantu ngirit sumber daya CPU lan nyuda swara latar mburi.",
     "Warming up... ({} blocks remaining)": "Panasake... ({} blok isih)",
     "You can also use a custom path.": "Sampeyan uga bisa nggunakake path kustom.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Dhukungan](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Dhukungan](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Tingkat sampel sing digunakake kanggo streaming audio. Ganti iki yen driver nglaporke tingkat sing salah (contone 48000 Hz tinimbang 44100 Hz)."
 }

--- a/assets/i18n/languages/ko_KO.json
+++ b/assets/i18n/languages/ko_KO.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "plugin.zip을 드래그하여 설치하세요",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "클릭을 방지하기 위한 오디오 청크 간 페이드 지속 시간입니다. 값이 높을수록 더 부드러운 전환을 만들지만 지연 시간이 증가할 수 있습니다.",
     "Embedder Model": "임베더 모델",
+    "Enable ASIO": "ASIO 활성화",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO 드라이버 지원을 활성화합니다. (Applio 재시작 필요)",
     "Enable Applio integration with Discord presence": "Discord Presence와 Applio 연동 활성화",
     "Enable VAD": "VAD 활성화",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "포먼트 시프팅을 활성화합니다. 남성에서 여성 또는 그 반대의 변환에 사용됩니다.",
@@ -134,9 +136,6 @@
     "File to Speech": "파일로 음성 합성",
     "Filter": "필터",
     "Folder Name": "폴더 이름",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO 드라이버의 경우 특정 입력 채널을 선택합니다. 기본값으로 두려면 -1로 남겨두세요.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO 드라이버의 경우 특정 모니터 출력 채널을 선택합니다. 기본값으로 두려면 -1로 남겨두세요.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO 드라이버의 경우 특정 출력 채널을 선택합니다. 기본값으로 두려면 -1로 남겨두세요.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI(Windows)의 경우, 앱에 독점 제어 권한을 부여하여 잠재적으로 더 낮은 지연 시간을 제공합니다.",
     "Formant Shifting": "포먼트 시프팅",
     "Fresh Training": "새 학습",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "리버브 웻 게인",
     "Reverb Width": "리버브 너비",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "전자음 같은 찢어짐이나 기타 잡음을 방지하기 위해 뚜렷한 자음과 숨소리를 보호합니다. 매개변수를 최댓값인 0.5로 설정하면 포괄적인 보호를 제공합니다. 그러나 이 값을 줄이면 보호 수준은 감소하지만 인덱싱 효과를 완화할 수 있습니다.",
+    "Sample Rate": "샘플 레이트",
     "Sampling Rate": "샘플링 레이트",
     "Save Every Epoch": "매 에포크마다 저장",
     "Save Every Weights": "매번 가중치 저장",
@@ -326,6 +326,7 @@
     "Start": "시작",
     "Start Training": "학습 시작",
     "Status": "상태",
+    "Stereo": "스테레오",
     "Stop": "중지",
     "Stop Training": "학습 중지",
     "Stop convert": "변환 중지",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "이 볼륨 레벨 이하의 오디오는 무음으로 간주되어 처리되지 않습니다. CPU 리소스를 절약하고 배경 소음을 줄이는 데 도움이 됩니다.",
     "Warming up... ({} blocks remaining)": "워밍업 중... ({}블록 남음)",
     "You can also use a custom path.": "사용자 지정 경로를 사용할 수도 있습니다.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[지원](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[지원](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "오디오 스트리밍에 사용되는 샘플 레이트입니다. 드라이버가 잘못된 레이트를 보고하는 경우 이를 재정의하세요 (예: 44100 Hz 대신 48000 Hz)."
 }

--- a/assets/i18n/languages/lt_LT.json
+++ b/assets/i18n/languages/lt_LT.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Nuvilkite savo plugin.zip, kad jį įdiegtumėte",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Garso fragmentų perėjimo trukmė, siekiant išvengti spragtelėjimų. Didesnės reikšmės sukuria sklandesnius perėjimus, bet gali padidinti delsą.",
     "Embedder Model": "Įterpimo modelis",
+    "Enable ASIO": "Įjungti ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Įjunkite ASIO tvarkyklės palaikymą. (Reikia perkrauti Applio)",
     "Enable Applio integration with Discord presence": "Įjungti Applio integraciją su Discord būsena",
     "Enable VAD": "Įjungti VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Įjungti formančių poslinkį. Naudojama konvertuojant vyrišką balsą į moterišką ir atvirkščiai.",
@@ -134,9 +136,6 @@
     "File to Speech": "Failas į kalbą",
     "Filter": "Filtras",
     "Folder Name": "Aplanko pavadinimas",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO tvarkyklėms: pasirenka konkretų įvesties kanalą. Palikite -1 numatytajai reikšmei.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO tvarkyklėms: pasirenka konkretų monitoringo išvesties kanalą. Palikite -1 numatytajai reikšmei.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO tvarkyklėms: pasirenka konkretų išvesties kanalą. Palikite -1 numatytajai reikšmei.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) atveju: suteikia programėlei išskirtinę kontrolę, galimai sumažinant delsą.",
     "Formant Shifting": "Formančių poslinkis",
     "Fresh Training": "Naujas apmokymas",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Reverberacijos šlapio signalo stiprinimas",
     "Reverb Width": "Reverberacijos plotis",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Apsaugokite aiškius priebalsius ir kvėpavimo garsus, kad išvengtumėte elektroakustinių iškraipymų ir kitų artefaktų. Nustačius parametrą į maksimalią 0.5 reikšmę, užtikrinama visapusiška apsauga. Tačiau sumažinus šią reikšmę, apsaugos lygis gali sumažėti, bet kartu gali būti sušvelnintas indeksavimo poveikis.",
+    "Sample Rate": "Diskretizavimo dažnis",
     "Sampling Rate": "Diskretizavimo dažnis",
     "Save Every Epoch": "Išsaugoti kas epochą",
     "Save Every Weights": "Išsaugoti visus svorius",
@@ -326,6 +326,7 @@
     "Start": "Pradėti",
     "Start Training": "Pradėti apmokymą",
     "Status": "Būsena",
+    "Stereo": "Stereo",
     "Stop": "Stabdyti",
     "Stop Training": "Sustabdyti apmokymą",
     "Stop convert": "Sustabdyti konvertavimą",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Garso lygis, žemiau kurio garsas laikomas tyla ir neapdorojamas. Padeda taupyti CPU resursus ir sumažinti foninį triukšmą.",
     "Warming up... ({} blocks remaining)": "Šildoma... (liko {} blokų)",
     "You can also use a custom path.": "Taip pat galite naudoti pasirinktinį kelią.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Pagalba](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Pagalba](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Diskretizavimo dažnis, naudojamas garso srautui. Pakeiskite tai, jei tvarkyklė praneša neteisingą dažnį (pvz. 48000 Hz vietoj 44100 Hz)."
 }

--- a/assets/i18n/languages/lv_LV.json
+++ b/assets/i18n/languages/lv_LV.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Ievelciet savu plugin.zip, lai to instalētu",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Audio segmentu sapludināšanas ilgums, lai novērstu klikšķus. Augstākas vērtības rada plūstošākas pārejas, bet var palielināt latentumu.",
     "Embedder Model": "Iegūlēja (Embedder) modelis",
+    "Enable ASIO": "Iespējot ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Iespējojiet ASIO draivera atbalstu. (Nepieciešama Applio restartēšana)",
     "Enable Applio integration with Discord presence": "Iespējot Applio integrāciju ar Discord klātbūtni",
     "Enable VAD": "Iespējot VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Iespējot formantu nobīdi. Izmanto vīriešu balss konvertēšanai uz sieviešu un otrādi.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fails uz runu",
     "Filter": "Filtrs",
     "Folder Name": "Mapes nosaukums",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO draiveriem, izvēlas konkrētu ievades kanālu. Atstājiet -1 noklusējuma vērtībai.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO draiveriem, izvēlas konkrētu monitora izejas kanālu. Atstājiet -1 noklusējuma vērtībai.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO draiveriem, izvēlas konkrētu izejas kanālu. Atstājiet -1 noklusējuma vērtībai.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) gadījumā, piešķir lietotnei ekskluzīvu kontroli, lai potenciāli samazinātu latentumu.",
     "Formant Shifting": "Formantu nobīde",
     "Fresh Training": "Apmācība no nulles",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Reverberācijas slapjais pastiprinājums",
     "Reverb Width": "Reverberācijas platums",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Aizsargājiet atšķirīgus līdzskaņus un elpošanas skaņas, lai novērstu elektroakustiskus kropļojumus un citus artefaktus. Parametra palielināšana līdz maksimālajai vērtībai 0.5 piedāvā visaptverošu aizsardzību. Tomēr šīs vērtības samazināšana var mazināt aizsardzības līmeni, potenciāli mazinot indeksēšanas efektu.",
+    "Sample Rate": "Izlases biežums",
     "Sampling Rate": "Izlases biežums",
     "Save Every Epoch": "Saglabāt katru epohu",
     "Save Every Weights": "Saglabāt visus svarus",
@@ -326,6 +326,7 @@
     "Start": "Sākt",
     "Start Training": "Sākt apmācību",
     "Status": "Statuss",
+    "Stereo": "Stereo",
     "Stop": "Apturēt",
     "Stop Training": "Pārtraukt apmācību",
     "Stop convert": "Pārtraukt konvertēšanu",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Skaļuma līmenis, zem kura audio tiek uzskatīts par klusumu un netiek apstrādāts. Palīdz ietaupīt CPU resursus un samazināt fona troksni.",
     "Warming up... ({} blocks remaining)": "Iesildīšana... (atlikuši {} bloki)",
     "You can also use a custom path.": "Varat izmantot arī pielāgotu ceļu.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Atbalsts](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Atbalsts](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Izlases biežums, ko izmanto audio straumēšanai. Aizstājiet šo, ja draiveris ziņo par nepareizu biežumu (piem. 48000 Hz, nevis 44100 Hz)."
 }

--- a/assets/i18n/languages/mg_MG.json
+++ b/assets/i18n/languages/mg_MG.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Tariho eto ny plugin.zip anao mba hametrahana azy",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Faharetan'ny fihenan'ny feo eo anelanelan'ny ampahany mba hisorohana ny 'clics'. Ny sanda ambony dia miteraka tetezamita milamina kokoa saingy mety hampitombo ny fahatarana.",
     "Embedder Model": "Maodely Embedder",
+    "Enable ASIO": "Alefaso ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Alefaso ny fanohanana ny driver ASIO. (Mila averina alefa ny Applio)",
     "Enable Applio integration with Discord presence": "Alefaso ny fampidirana ny Applio amin'ny fisian'ny Discord",
     "Enable VAD": "Alefaso ny VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Alefaso ny formant shifting. Ampiasaina amin'ny fanovana feo lahy ho vavy ary ny mifamadika amin'izany.",
@@ -134,9 +136,6 @@
     "File to Speech": "Rakitra ho Lahateny",
     "Filter": "Sivana",
     "Folder Name": "Anaran'ny Lahatahiry",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Ho an'ny mpamily ASIO, mifidy fantsona fampidirana manokana. Avelao ho -1 raha tiana ny mahazatra.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Ho an'ny mpamily ASIO, mifidy fantsona fivoahana fanaraha-maso manokana. Avelao ho -1 raha tiana ny mahazatra.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Ho an'ny mpamily ASIO, mifidy fantsona fivoahana manokana. Avelao ho -1 raha tiana ny mahazatra.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Ho an'ny WASAPI (Windows), manome fifehezana manokana ho an'ny fampiharana mba hahazoana fahatarana ambany kokoa.",
     "Formant Shifting": "Formant Shifting",
     "Fresh Training": "Fanofanana Vaovao",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Gain Lena Reverb",
     "Reverb Width": "Sakan'ny Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Arovy ny renifeo miavaka sy ny feon'ny fisefoana mba hisorohana ny fahasimbana elektro-akostika sy ny lesoka hafa. Ny fisintonana ny masontsivana ho amin'ny sandany ambony indrindra 0.5 dia manome fiarovana feno. Na izany aza, ny fampihenana ity sanda ity dia mety hampihena ny fiarovana sady mety hanamaivana ny vokatry ny fanondroana.",
+    "Sample Rate": "Tahan'ny Santiona",
     "Sampling Rate": "Tahan'ny Fakan-tsantionany",
     "Save Every Epoch": "Tehirizo isaky ny Epoch",
     "Save Every Weights": "Tehirizo ny Lanja Rehetra",
@@ -326,6 +326,7 @@
     "Start": "Atombohy",
     "Start Training": "Atombohy ny Fanofanana",
     "Status": "Sata",
+    "Stereo": "Stereo",
     "Stop": "Atsaharo",
     "Stop Training": "Atsaharo ny Fanofanana",
     "Stop convert": "Atsaharo ny fanovana",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Haavon'ny feo izay heverina ho fahanginana ary tsy karakaraina ny feo eo ambaniny. Manampy amin'ny fitsitsiana ny loharanon-karen'ny CPU sy mampihena ny tabataba any aoriana.",
     "Warming up... ({} blocks remaining)": "Mafana... ({} bolongana sisa)",
     "You can also use a custom path.": "Afaka mampiasa lalana manokana koa ianao.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Fanohanana](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Fanohanana](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Tahan'ny santiona ampiasaina ho an'ny fampitana feo. Hanovana izany raha milaza tahan'ny diso ny mpamily (ohatra 48000 Hz fa tsy 44100 Hz)."
 }

--- a/assets/i18n/languages/ml_IN.json
+++ b/assets/i18n/languages/ml_IN.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "ഇൻസ്റ്റാൾ ചെയ്യാൻ നിങ്ങളുടെ plugin.zip വലിച്ചിടുക",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "ക്ലിക്കുകൾ തടയാൻ ഓഡിയോ ചങ്കുകൾക്കിടയിലുള്ള ഫേഡിന്റെ ദൈർഘ്യം. ഉയർന്ന മൂല്യങ്ങൾ സുഗമമായ മാറ്റങ്ങൾ നൽകുമെങ്കിലും ലേറ്റൻസി വർദ്ധിപ്പിച്ചേക്കാം.",
     "Embedder Model": "എംബെഡർ മോഡൽ",
+    "Enable ASIO": "ASIO പ്രവർത്തനക്ഷമമാക്കുക",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO ഡ്രൈവർ പിന്തുണ പ്രവർത്തനക്ഷമമാക്കുക. (Applio പുനരാരംഭിക്കേണ്ടതുണ്ട്)",
     "Enable Applio integration with Discord presence": "ഡിസ്കോർഡ് പ്രെസൻസുമായി Applio സംയോജനം പ്രവർത്തനക്ഷമമാക്കുക",
     "Enable VAD": "VAD പ്രവർത്തനക്ഷമമാക്കുക",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "ഫോർമാന്റ് ഷിഫ്റ്റിംഗ് പ്രവർത്തനക്ഷമമാക്കുക. പുരുഷനിൽ നിന്ന് സ്ത്രീയിലേക്കും തിരിച്ചുമുള്ള പരിവർത്തനങ്ങൾക്ക് ഉപയോഗിക്കുന്നു.",
@@ -134,9 +136,6 @@
     "File to Speech": "ഫയലിൽ നിന്ന് സംഭാഷണം",
     "Filter": "ഫിൽട്ടർ",
     "Folder Name": "ഫോൾഡറിന്റെ പേര്",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO ഡ്രൈവറുകൾക്കായി, ഒരു പ്രത്യേക ഇൻപുട്ട് ചാനൽ തിരഞ്ഞെടുക്കുന്നു. ഡിഫോൾട്ടിനായി -1 ൽ വിടുക.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO ഡ്രൈവറുകൾക്കായി, ഒരു പ്രത്യേക മോണിറ്റർ ഔട്ട്പുട്ട് ചാനൽ തിരഞ്ഞെടുക്കുന്നു. ഡിഫോൾട്ടിനായി -1 ൽ വിടുക.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO ഡ്രൈവറുകൾക്കായി, ഒരു പ്രത്യേക ഔട്ട്പുട്ട് ചാനൽ തിരഞ്ഞെടുക്കുന്നു. ഡിഫോൾട്ടിനായി -1 ൽ വിടുക.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (വിൻഡോസ്)-നായി, കുറഞ്ഞ ലേറ്റൻസിക്ക് വേണ്ടി ആപ്പിന് എക്സ്ക്ലൂസീവ് നിയന്ത്രണം നൽകുന്നു.",
     "Formant Shifting": "ഫോർമാന്റ് ഷിഫ്റ്റിംഗ്",
     "Fresh Training": "പുതിയ പരിശീലനം",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "റിവേർബ് വെറ്റ് ഗെയിൻ",
     "Reverb Width": "റിവേർബ് വീതി",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "ഇലക്ട്രോ-അക്കോസ്റ്റിക് ടിയറിംഗും മറ്റ് ആർട്ടിഫാക്റ്റുകളും തടയുന്നതിന് വ്യതിരിക്തമായ വ്യഞ്ജനാക്ഷരങ്ങളെയും ശ്വാസമെടുക്കുന്ന ശബ്ദങ്ങളെയും സംരക്ഷിക്കുക. പാരാമീറ്റർ അതിന്റെ പരമാവധി മൂല്യമായ 0.5-ലേക്ക് വലിക്കുന്നത് സമഗ്രമായ സംരക്ഷണം നൽകുന്നു. എന്നിരുന്നാലും, ഈ മൂല്യം കുറയ്ക്കുന്നത് സംരക്ഷണത്തിന്റെ വ്യാപ്തി കുറയ്ക്കുകയും ഇൻഡെക്സിംഗ് പ്രഭാവം ലഘൂകരിക്കുകയും ചെയ്യും.",
+    "Sample Rate": "സാമ്പിൾ നിരക്ക്",
     "Sampling Rate": "സാമ്പിളിംഗ് നിരക്ക്",
     "Save Every Epoch": "ഓരോ എപ്പോക്കിലും സംരക്ഷിക്കുക",
     "Save Every Weights": "എല്ലാ വെയ്റ്റുകളും സംരക്ഷിക്കുക",
@@ -326,6 +326,7 @@
     "Start": "തുടങ്ങുക",
     "Start Training": "പരിശീലനം ആരംഭിക്കുക",
     "Status": "നില",
+    "Stereo": "സ്റ്റീരിയോ",
     "Stop": "നിർത്തുക",
     "Stop Training": "പരിശീലനം നിർത്തുക",
     "Stop convert": "പരിവർത്തനം നിർത്തുക",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "ഓഡിയോ നിശ്ശബ്ദമായി കണക്കാക്കുന്ന വോളിയം പരിധി. ഇത് CPU വിഭവങ്ങൾ ലാഭിക്കാനും പശ്ചാത്തല ശബ്ദം കുറയ്ക്കാനും സഹായിക്കുന്നു.",
     "Warming up... ({} blocks remaining)": "വാമിംഗ് അപ്... ({} ബ്ലോക്കുകൾ ശേഷിക്കുന്നു)",
     "You can also use a custom path.": "നിങ്ങൾക്ക് ഒരു കസ്റ്റം പാതയും ഉപയോഗിക്കാം.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[പിന്തുണ](https://discord.gg/urxFjYmYYh) — [ഗിറ്റ്ഹബ്ബ്](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[പിന്തുണ](https://discord.gg/urxFjYmYYh) — [ഗിറ്റ്ഹബ്ബ്](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "ഓഡിയോ സ്ട്രീമിങ്ങിനായി ഉപയോഗിക്കുന്ന സാമ്പിൾ നിരക്ക്. ഡ്രൈവർ തെറ്റായ നിരക്ക് റിപ്പോർട്ട് ചെയ്യുന്നുണ്ടെങ്കിൽ ഇത് ഓവർറൈഡ് ചെയ്യുക (ഉദാ. 44100 Hz ന് പകരം 48000 Hz)."
 }

--- a/assets/i18n/languages/mr_MR.json
+++ b/assets/i18n/languages/mr_MR.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "तुमचा plugin.zip इन्स्टॉल करण्यासाठी येथे ड्रॅग करा",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "क्लिक टाळण्यासाठी ऑडिओ चंक्समधील फेडचा कालावधी. उच्च मूल्ये नितळ संक्रमण तयार करतात परंतु लेटन्सी वाढवू शकतात.",
     "Embedder Model": "एम्बेडर मॉडेल",
+    "Enable ASIO": "ASIO सक्षम करा",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO ड्रायव्हर समर्थन सक्षम करा. (Applio पुन्हा सुरू करणे आवश्यक आहे)",
     "Enable Applio integration with Discord presence": "Discord प्रेझेन्ससह Applio इंटिग्रेशन सक्षम करा",
     "Enable VAD": "VAD सक्षम करा",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "फॉर्मंट शिफ्टिंग सक्षम करा. पुरुष ते महिला आणि उलट रूपांतरणासाठी वापरले जाते.",
@@ -134,9 +136,6 @@
     "File to Speech": "फाईल टू स्पीच",
     "Filter": "फिल्टर",
     "Folder Name": "फोल्डरचे नाव",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO ड्रायव्हर्ससाठी, एक विशिष्ट इनपुट चॅनेल निवडते. डीफॉल्टसाठी -1 वर सोडा.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO ड्रायव्हर्ससाठी, एक विशिष्ट मॉनिटर आउटपुट चॅनेल निवडते. डीफॉल्टसाठी -1 वर सोडा.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO ड्रायव्हर्ससाठी, एक विशिष्ट आउटपुट चॅनेल निवडते. डीफॉल्टसाठी -1 वर सोडा.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) साठी, संभाव्यतः कमी लेटन्सीसाठी ॲपला एक्सक्लुझिव्ह नियंत्रण देते.",
     "Formant Shifting": "फॉर्मंट शिफ्टिंग",
     "Fresh Training": "नवीन ट्रेनिंग",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "रिव्हर्ब वेट गेन",
     "Reverb Width": "रिव्हर्ब विड्थ",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "इलेक्ट्रो-अकौस्टिक टेअरिंग आणि इतर कलाकृती टाळण्यासाठी वेगळे व्यंजन आणि श्वासाचे आवाज सुरक्षित ठेवा. पॅरामीटरला त्याच्या कमाल मूल्य ०.५ पर्यंत खेचल्यास सर्वसमावेशक संरक्षण मिळते. तथापि, हे मूल्य कमी केल्याने संरक्षणाची व्याप्ती कमी होऊ शकते आणि संभाव्यतः इंडेक्सिंग प्रभाव कमी होऊ शकतो.",
+    "Sample Rate": "नमुना दर",
     "Sampling Rate": "सॅम्पलिंग रेट",
     "Save Every Epoch": "प्रत्येक इपॉकला सेव्ह करा",
     "Save Every Weights": "प्रत्येक वेट्स सेव्ह करा",
@@ -326,6 +326,7 @@
     "Start": "सुरू करा",
     "Start Training": "ट्रेनिंग सुरू करा",
     "Status": "स्थिती",
+    "Stereo": "स्टीरिओ",
     "Stop": "थांबा",
     "Stop Training": "ट्रेनिंग थांबवा",
     "Stop convert": "रूपांतरण थांबवा",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "व्हॉल्यूम पातळी ज्याच्या खाली ऑडिओ शांतता मानला जातो आणि त्यावर प्रक्रिया केली जात नाही. हे CPU संसाधने वाचविण्यात आणि पार्श्वभूमीतील आवाज कमी करण्यास मदत करते.",
     "Warming up... ({} blocks remaining)": "वॉर्मिंग अप... ({} ब्लॉक शिल्लक)",
     "You can also use a custom path.": "तुम्ही कस्टम मार्ग देखील वापरू शकता.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[समर्थन](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[समर्थन](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "ऑडिओ स्ट्रीमिंगसाठी वापरलेला नमुना दर. ड्रायव्हर चुकीचा दर नोंदवत असल्यास हे बदला (उदा. 44100 Hz ऐवजी 48000 Hz)."
 }

--- a/assets/i18n/languages/ms_MS.json
+++ b/assets/i18n/languages/ms_MS.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Seret plugin.zip anda untuk memasangnya",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Tempoh pudar antara cebisan audio untuk mengelakkan bunyi 'klik'. Nilai yang lebih tinggi menghasilkan peralihan yang lebih lancar tetapi mungkin meningkatkan kependaman.",
     "Embedder Model": "Model Pembedam",
+    "Enable ASIO": "Aktifkan ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Aktifkan sokongan pemacu ASIO. (Memerlukan Applio dimulakan semula)",
     "Enable Applio integration with Discord presence": "Dayakan integrasi Applio dengan kehadiran Discord",
     "Enable VAD": "Aktifkan VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Dayakan anjakan forman. Digunakan untuk penukaran lelaki ke perempuan dan sebaliknya.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fail ke Ucapan",
     "Filter": "Penapis",
     "Folder Name": "Nama Folder",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Untuk pemacu ASIO, pilih saluran input tertentu. Biarkan pada -1 untuk lalai.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Untuk pemacu ASIO, pilih saluran output monitor tertentu. Biarkan pada -1 untuk lalai.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Untuk pemacu ASIO, pilih saluran output tertentu. Biarkan pada -1 untuk lalai.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Untuk WASAPI (Windows), memberikan aplikasi kawalan eksklusif untuk potensi kependaman yang lebih rendah.",
     "Formant Shifting": "Anjakan Forman",
     "Fresh Training": "Latihan Baharu",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Gandaan Basah Gema",
     "Reverb Width": "Lebar Gema",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Lindungi konsonan yang berbeza dan bunyi pernafasan untuk mengelakkan koyakan elektro-akustik dan artefak lain. Menarik parameter ke nilai maksimumnya iaitu 0.5 menawarkan perlindungan komprehensif. Walau bagaimanapun, mengurangkan nilai ini mungkin mengurangkan tahap perlindungan sambil berpotensi mengurangkan kesan pengindeksan.",
+    "Sample Rate": "Kadar Sampel",
     "Sampling Rate": "Kadar Pensampelan",
     "Save Every Epoch": "Simpan Setiap Epok",
     "Save Every Weights": "Simpan Setiap Pemberat",
@@ -326,6 +326,7 @@
     "Start": "Mula",
     "Start Training": "Mula Latihan",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Henti",
     "Stop Training": "Henti Latihan",
     "Stop convert": "Henti tukar",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Tahap kelantangan di mana audio dianggap sebagai senyap dan tidak diproses. Membantu menjimatkan sumber CPU dan mengurangkan hingar latar.",
     "Warming up... ({} blocks remaining)": "Memanaskan... ({} blok berbaki)",
     "You can also use a custom path.": "Anda juga boleh menggunakan laluan tersuai.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Sokongan](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Sokongan](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Kadar sampel yang digunakan untuk penstriman audio. Ganti ini jika pemacu melaporkan kadar yang tidak betul (cth. 48000 Hz dan bukannya 44100 Hz)."
 }

--- a/assets/i18n/languages/mt_MT.json
+++ b/assets/i18n/languages/mt_MT.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Ikaxkar il-plugin.zip tiegħek biex tinstallah",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Tul tal-fade bejn il-blokki tal-awdjo biex jiġu evitati l-ħsejjes (clicks). Valuri ogħla joħolqu tranżizzjonijiet aktar fluwidi imma jistgħu jżidu d-dewmien (latency).",
     "Embedder Model": "Mudell tal-Embedder",
+    "Enable ASIO": "Ippermetti ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Ippermetti l-appoġġ tal-driver ASIO. (Jeħtieġ li terġa' tibda Applio)",
     "Enable Applio integration with Discord presence": "Attiva l-integrazzjoni ta' Applio mal-preżenza ta' Discord",
     "Enable VAD": "Attiva VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Attiva l-formant shifting. Użat għal konverżjonijiet minn raġel għal mara u viċi versa.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fajl għad-Diskors",
     "Filter": "Filtru",
     "Folder Name": "Isem tal-Folder",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Għad-drivers ASIO, jagħżel kanal speċifiku tal-input. Ħallih fuq -1 għall-default.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Għad-drivers ASIO, jagħżel kanal speċifiku tal-output tal-monitor. Ħallih fuq -1 għall-default.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Għad-drivers ASIO, jagħżel kanal speċifiku tal-output. Ħallih fuq -1 għall-default.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Għal WASAPI (Windows), jagħti lill-app kontroll esklussiv għal dewmien (latency) potenzjalment aktar baxx.",
     "Formant Shifting": "Formant Shifting",
     "Fresh Training": "Taħriġ Frisk",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Wet Gain tar-Reverb",
     "Reverb Width": "Wisa' tar-Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Issalvagwardja l-konsonanti distinti u l-ħsejjes tan-nifs biex tevita tiċrit elettro-akustiku u artifatti oħra. It-tlugħ tal-parametru sal-valur massimu tiegħu ta' 0.5 joffri protezzjoni komprensiva. Madankollu, it-tnaqqis ta' dan il-valur jista' jnaqqas il-firxa tal-protezzjoni filwaqt li potenzjalment itaffi l-effett tal-indiċjar.",
+    "Sample Rate": "Rata tal-Kampjun",
     "Sampling Rate": "Rata ta' Kampjunar",
     "Save Every Epoch": "Issejvja Kull Epoka",
     "Save Every Weights": "Issejvja Kull Piż",
@@ -326,6 +326,7 @@
     "Start": "Ibda",
     "Start Training": "Ibda t-Taħriġ",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Waqqaf",
     "Stop Training": "Waqqaf it-Taħriġ",
     "Stop convert": "Waqqaf il-konverżjoni",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Il-livell tal-volum li taħtu l-awdjo jiġi ttrattat bħala silenzju u ma jiġix ipproċessat. Jgħin biex jiffranka r-riżorsi tas-CPU u jnaqqas il-ħoss fl-isfond.",
     "Warming up... ({} blocks remaining)": "Tisħin... ({} blokki fadal)",
     "You can also use a custom path.": "Tista' wkoll tuża post personalizzat.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Appoġġ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Appoġġ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Rata tal-kampjun użata għall-istreaming tal-awdjo. Ibdel dan jekk il-driver jirrapporta rata incorretta (eż. 48000 Hz minflok 44100 Hz)."
 }

--- a/assets/i18n/languages/nl_NL.json
+++ b/assets/i18n/languages/nl_NL.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Sleep uw plugin.zip hierheen om het te installeren",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Duur van de overgang tussen audiochunks om klikken te voorkomen. Hogere waarden creëren vloeiendere overgangen, maar kunnen de latentie verhogen.",
     "Embedder Model": "Embedder-model",
+    "Enable ASIO": "ASIO inschakelen",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO-stuurprogramma-ondersteuning inschakelen. (Vereist herstarten van Applio)",
     "Enable Applio integration with Discord presence": "Applio-integratie met Discord-aanwezigheid inschakelen",
     "Enable VAD": "VAD inschakelen",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Formantverschuiving inschakelen. Wordt gebruikt voor conversies van man naar vrouw en vice versa.",
@@ -134,9 +136,6 @@
     "File to Speech": "Bestand naar Spraak",
     "Filter": "Filter",
     "Folder Name": "Mapnaam",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Voor ASIO-drivers, selecteert een specifiek ingangskanaal. Laat op -1 staan voor standaard.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Voor ASIO-drivers, selecteert een specifiek monitoruitgangskanaal. Laat op -1 staan voor standaard.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Voor ASIO-drivers, selecteert een specifiek uitgangskanaal. Laat op -1 staan voor standaard.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Voor WASAPI (Windows), geeft de app exclusieve controle voor mogelijk lagere latentie.",
     "Formant Shifting": "Formantverschuiving",
     "Fresh Training": "Nieuwe Training",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Galm Natte Gain",
     "Reverb Width": "Galmbreedte",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Bescherm duidelijke medeklinkers en ademgeluiden om elektro-akoestische vervorming en andere artefacten te voorkomen. Het instellen van de parameter op de maximale waarde van 0.5 biedt uitgebreide bescherming. Echter, het verlagen van deze waarde kan de mate van bescherming verminderen, terwijl het mogelijk het indexeringseffect verzacht.",
+    "Sample Rate": "Samplefrequentie",
     "Sampling Rate": "Samplefrequentie",
     "Save Every Epoch": "Elke Epoch Opslaan",
     "Save Every Weights": "Alle Gewichten Opslaan",
@@ -326,6 +326,7 @@
     "Start": "Start",
     "Start Training": "Training Starten",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Stop",
     "Stop Training": "Training Stoppen",
     "Stop convert": "Converteren stoppen",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Volumeniveau waaronder audio als stilte wordt behandeld en niet wordt verwerkt. Helpt CPU-bronnen te besparen en achtergrondgeluid te verminderen.",
     "Warming up... ({} blocks remaining)": "Opwarmen... ({} blokken resterend)",
     "You can also use a custom path.": "U kunt ook een aangepast pad gebruiken.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Ondersteuning](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Ondersteuning](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Samplefrequentie die wordt gebruikt voor audiostreaming. Overschrijf dit als de driver een onjuiste frequentie rapporteert (bijv. 48000 Hz in plaats van 44100 Hz)."
 }

--- a/assets/i18n/languages/otq_OTQ.json
+++ b/assets/i18n/languages/otq_OTQ.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Arrastra ir plugin.zip pa instalarlo",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Duración ar desvanecimiento entre ya trozos ar audio pa hingi nja ya clics. Ya hñei más altos pe̱'tsi transiciones más suaves pero tsa ñäni ar latencia.",
     "Embedder Model": "Modelo Incrustador",
+    "Enable ASIO": "Habilitär ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Habilitär el soporte del driver ASIO. (Requiere reiniciar Applio)",
     "Enable Applio integration with Discord presence": "Habilita ar integración de Applio ko ar presencia de Discord",
     "Enable VAD": "Pe̱hni VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Habilita ar cambio de formantes. Se usa pa njot'i de ñ'o̲ho̲ ma 'ñäni ne viceversa.",
@@ -134,9 +136,6 @@
     "File to Speech": "Hets'i ma Hñä",
     "Filter": "Filter",
     "Folder Name": "Thuhu de Carpeta",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Pa ya controladores ASIO, pe̱hni 'nar canal entrada específico. Deja ja -1 pa ar predeterminado.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Pa ya controladores ASIO, pe̱hni 'nar canal salida monitor específico. Deja ja -1 pa ar predeterminado.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Pa ya controladores ASIO, pe̱hni 'nar canal salida específico. Deja ja -1 pa ar predeterminado.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Pa WASAPI (Windows), uni ar nt'ot'e control exclusivo pa 'nar latencia potencialmente más hñets'i.",
     "Formant Shifting": "Cambio de Formantes",
     "Fresh Training": "Entrenamiento 'Ra'yo",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Ganancia Húmeda de Reverberación",
     "Reverb Width": "Ancho de Reverberación",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Protege ya consonantes distintas ne ya ya'bu̲ de respiración pa nu'bu da 'nar desgarro electroacústico ne ma'ra artefactos. Llevar ar parámetro ma ár hñei máximo de 0.5 ofrece 'nar protección integral. Wat'i, reducir nuna ar hñei podría disminuir ar alcance de ar protección mi mientra mitiga ar efecto de indexación.",
+    "Sample Rate": "Tasa de Muestreo",
     "Sampling Rate": "Frecuencia de Muestreo",
     "Save Every Epoch": "Guardar 'nar Época",
     "Save Every Weights": "Guardar 'nar Pesos",
@@ -326,6 +326,7 @@
     "Start": "Du'mi",
     "Start Training": "M'u̲i Entrenamiento",
     "Status": "Estado",
+    "Stereo": "Estéreo",
     "Stop": "Poni",
     "Stop Training": "Pa'i Entrenamiento",
     "Stop convert": "Pa'i njot'i",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Nivel ar ndähi debajo ar cual ar audio ar trata komongu silencio ne hingi ar procesa. Ayuda pa hingi gastar recursos CPU ne reducir ar ruido ar fondo.",
     "Warming up... ({} blocks remaining)": "Warming up... ({} bloques di faltan)",
     "You can also use a custom path.": "También tsa̲ da usar 'nar ruta personalizada.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Soporte](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Soporte](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Tasa de muestreo usadä para transmisión de audio. Anulä esto si el driver reportä una tasa incorrectä (ej. 48000 Hz en lugar de 44100 Hz)."
 }

--- a/assets/i18n/languages/pa_PA.json
+++ b/assets/i18n/languages/pa_PA.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "ਇਸਨੂੰ ਸਥਾਪਿਤ ਕਰਨ ਲਈ ਆਪਣੀ plugin.zip ਫਾਈਲ ਨੂੰ ਖਿੱਚੋ",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "ਕਲਿੱਕਾਂ ਨੂੰ ਰੋਕਣ ਲਈ ਆਡੀਓ ਚੰਕਸ ਦੇ ਵਿਚਕਾਰ ਫੇਡ ਦੀ ਮਿਆਦ। ਉੱਚੇ ਮੁੱਲ ਨਿਰਵਿਘਨ ਤਬਦੀਲੀਆਂ ਬਣਾਉਂਦੇ ਹਨ ਪਰ ਲੇਟੈਂਸੀ ਵਧਾ ਸਕਦੇ ਹਨ।",
     "Embedder Model": "ਏਮਬੇਡਰ ਮਾਡਲ",
+    "Enable ASIO": "ASIO ਸਮਰੱਥ ਕਰੋ",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO ਡਰਾਈਵਰ ਸਮਰਥਨ ਸਮਰੱਥ ਕਰੋ। ASIO ਡਿਵਾਈਸ ਨੂੰ ਇਨਪੁੱਟ/ਆਉਟਪੁੱਟ ਵਜੋਂ ਚੁਣੋ ਅਤੇ ਉੱਪਰ ਚੈਨਲ ਨੰਬਰ ਸੈੱਟ ਕਰੋ। ਬਦਲਾਅ ਲਾਗੂ ਕਰਨ ਲਈ Applio ਨੂੰ ਮੁੜ ਚਾਲੂ ਕਰਨਾ ਜ਼ਰੂਰੀ ਹੈ।(Applio ਨੂੰ ਮੁੜ-ਚਾਲੂ ਕਰਨ ਦੀ ਲੋੜ ਹੈ)",
     "Enable Applio integration with Discord presence": "Discord ਮੌਜੂਦਗੀ ਨਾਲ Applio ਏਕੀਕਰਣ ਨੂੰ ਸਮਰੱਥ ਕਰੋ",
     "Enable VAD": "VAD ਨੂੰ ਸਮਰੱਥ ਕਰੋ",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "ਫਾਰਮੈਂਟ ਸ਼ਿਫਟਿੰਗ ਨੂੰ ਸਮਰੱਥ ਕਰੋ। ਮਰਦ ਤੋਂ ਔਰਤ ਅਤੇ ਇਸਦੇ ਉਲਟ ਪਰਿਵਰਤਨ ਲਈ ਵਰਤਿਆ ਜਾਂਦਾ ਹੈ।",
@@ -134,9 +136,6 @@
     "File to Speech": "ਫਾਈਲ ਤੋਂ ਬੋਲੀ",
     "Filter": "ਫਿਲਟਰ",
     "Folder Name": "ਫੋਲਡਰ ਦਾ ਨਾਮ",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO ਡਰਾਈਵਰਾਂ ਲਈ, ਇੱਕ ਖਾਸ ਇਨਪੁਟ ਚੈਨਲ ਚੁਣਦਾ ਹੈ। ਡਿਫੌਲਟ ਲਈ -1 'ਤੇ ਛੱਡੋ।",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO ਡਰਾਈਵਰਾਂ ਲਈ, ਇੱਕ ਖਾਸ ਮਾਨੀਟਰ ਆਉਟਪੁੱਟ ਚੈਨਲ ਚੁਣਦਾ ਹੈ। ਡਿਫੌਲਟ ਲਈ -1 'ਤੇ ਛੱਡੋ।",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO ਡਰਾਈਵਰਾਂ ਲਈ, ਇੱਕ ਖਾਸ ਆਉਟਪੁੱਟ ਚੈਨਲ ਚੁਣਦਾ ਹੈ। ਡਿਫੌਲਟ ਲਈ -1 'ਤੇ ਛੱਡੋ।",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) ਲਈ, ਐਪ ਨੂੰ ਸੰਭਾਵੀ ਤੌਰ 'ਤੇ ਘੱਟ ਲੇਟੈਂਸੀ ਲਈ ਵਿਸ਼ੇਸ਼ ਨਿਯੰਤਰਣ ਦਿੰਦਾ ਹੈ।",
     "Formant Shifting": "ਫਾਰਮੈਂਟ ਸ਼ਿਫਟਿੰਗ",
     "Fresh Training": "ਤਾਜ਼ਾ ਸਿਖਲਾਈ",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "ਰੀਵਰਬ ਵੈੱਟ ਗੇਨ",
     "Reverb Width": "ਰੀਵਰਬ ਚੌੜਾਈ",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "ਵੱਖ-ਵੱਖ ਵਿਅੰਜਨਾਂ ਅਤੇ ਸਾਹ ਲੈਣ ਦੀਆਂ ਆਵਾਜ਼ਾਂ ਨੂੰ ਇਲੈਕਟ੍ਰੋ-ਅਕੌਸਟਿਕ ਫਟਣ ਅਤੇ ਹੋਰ ਕਲਾਤਮਕ ਚੀਜ਼ਾਂ ਤੋਂ ਬਚਾਉਣ ਲਈ ਸੁਰੱਖਿਅਤ ਕਰੋ। ਪੈਰਾਮੀਟਰ ਨੂੰ ਇਸਦੇ ਵੱਧ ਤੋਂ ਵੱਧ ਮੁੱਲ 0.5 'ਤੇ ਖਿੱਚਣਾ ਵਿਆਪਕ ਸੁਰੱਖਿਆ ਪ੍ਰਦਾਨ ਕਰਦਾ ਹੈ। ਹਾਲਾਂਕਿ, ਇਸ ਮੁੱਲ ਨੂੰ ਘਟਾਉਣ ਨਾਲ ਸੁਰੱਖਿਆ ਦੀ ਹੱਦ ਘੱਟ ਸਕਦੀ ਹੈ ਜਦਕਿ ਸੰਭਾਵੀ ਤੌਰ 'ਤੇ ਇੰਡੈਕਸਿੰਗ ਪ੍ਰਭਾਵ ਨੂੰ ਘੱਟ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ।",
+    "Sample Rate": "ਸੈਂਪਲ ਦਰ",
     "Sampling Rate": "ਨਮੂਨਾ ਦਰ",
     "Save Every Epoch": "ਹਰ ਯੁੱਗ ਨੂੰ ਸੁਰੱਖਿਅਤ ਕਰੋ",
     "Save Every Weights": "ਹਰ ਵਜ਼ਨ ਨੂੰ ਸੁਰੱਖਿਅਤ ਕਰੋ",
@@ -326,6 +326,7 @@
     "Start": "ਸ਼ੁਰੂ ਕਰੋ",
     "Start Training": "ਸਿਖਲਾਈ ਸ਼ੁਰੂ ਕਰੋ",
     "Status": "ਸਥਿਤੀ",
+    "Stereo": "ਸਟੀਰਿਓ",
     "Stop": "ਰੋਕੋ",
     "Stop Training": "ਸਿਖਲਾਈ ਰੋਕੋ",
     "Stop convert": "ਬਦਲਣਾ ਬੰਦ ਕਰੋ",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "ਵਾਲੀਅਮ ਦਾ ਪੱਧਰ ਜਿਸ ਤੋਂ ਹੇਠਾਂ ਆਡੀਓ ਨੂੰ ਚੁੱਪ ਮੰਨਿਆ ਜਾਂਦਾ ਹੈ ਅਤੇ ਪ੍ਰੋਸੈਸ ਨਹੀਂ ਕੀਤਾ ਜਾਂਦਾ ਹੈ। CPU ਸਰੋਤਾਂ ਨੂੰ ਬਚਾਉਣ ਅਤੇ ਪਿਛੋਕੜ ਦੇ ਸ਼ੋਰ ਨੂੰ ਘਟਾਉਣ ਵਿੱਚ ਮਦਦ ਕਰਦਾ ਹੈ।",
     "Warming up... ({} blocks remaining)": "ਵਾਰਮਿੰਗ ਅੱਪ... ({} ਬਲਾਕ ਬਾਕੀ)",
     "You can also use a custom path.": "ਤੁਸੀਂ ਇੱਕ ਕਸਟਮ ਮਾਰਗ ਦੀ ਵਰਤੋਂ ਵੀ ਕਰ ਸਕਦੇ ਹੋ।",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[ਸਮਰਥਨ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[ਸਮਰਥਨ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "ਆਡੀਓ ਸਟ੍ਰੀਮਿੰਗ ਲਈ ਵਰਤੀ ਗਈ ਸੈਂਪਲ ਦਰ। ਜੇ ਡਰਾਈਵਰ ਗਲਤ ਦਰ ਦੱਸੇ ਤਾਂ ਇਸਨੂੰ ਬਦਲੋ (ਜਿਵੇਂ 44100 Hz ਦੀ ਬਜਾਏ 48000 Hz)।"
 }

--- a/assets/i18n/languages/pl_PL.json
+++ b/assets/i18n/languages/pl_PL.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Przeciągnij swój plik plugin.zip, aby go zainstalować",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Czas trwania przenikania między fragmentami audio, aby zapobiec trzaskom. Wyższe wartości tworzą płynniejsze przejścia, ale mogą zwiększyć opóźnienie.",
     "Embedder Model": "Model embeddera",
+    "Enable ASIO": "Włącz ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Włącz obsługę sterownika ASIO. (Wymaga ponownego uruchomienia Applio)",
     "Enable Applio integration with Discord presence": "Włącz integrację Applio ze statusem Discord",
     "Enable VAD": "Włącz VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Włącz przesunięcie formantów. Używane do konwersji z głosu męskiego na żeński i na odwrót.",
@@ -134,9 +136,6 @@
     "File to Speech": "Plik na mowę",
     "Filter": "Filtr",
     "Folder Name": "Nazwa folderu",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Dla sterowników ASIO, wybiera określony kanał wejściowy. Pozostaw -1 dla wartości domyślnej.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Dla sterowników ASIO, wybiera określony kanał wyjściowy odsłuchu. Pozostaw -1 dla wartości domyślnej.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Dla sterowników ASIO, wybiera określony kanał wyjściowy. Pozostaw -1 dla wartości domyślnej.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Dla WASAPI (Windows), daje aplikacji wyłączną kontrolę w celu potencjalnie niższego opóźnienia.",
     "Formant Shifting": "Przesunięcie formantów",
     "Fresh Training": "Świeży trening",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Wzmocnienie sygnału mokrego (reverb)",
     "Reverb Width": "Szerokość pogłosu",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Chroń wyraziste spółgłoski i dźwięki oddechu, aby zapobiec rozrywaniu elektroakustycznemu i innym artefaktom. Ustawienie parametru na maksymalną wartość 0.5 oferuje kompleksową ochronę. Jednakże, zmniejszenie tej wartości może obniżyć poziom ochrony, jednocześnie potencjalnie łagodząc efekt indeksowania.",
+    "Sample Rate": "Częstotliwość próbkowania",
     "Sampling Rate": "Częstotliwość próbkowania",
     "Save Every Epoch": "Zapisuj co epokę",
     "Save Every Weights": "Zapisuj każdą wagę",
@@ -326,6 +326,7 @@
     "Start": "Uruchom",
     "Start Training": "Rozpocznij trening",
     "Status": "Status",
+    "Stereo": "Stereo",
     "Stop": "Zatrzymaj",
     "Stop Training": "Zatrzymaj trening",
     "Stop convert": "Zatrzymaj konwersję",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Poziom głośności, poniżej którego dźwięk jest traktowany jako cisza i nie jest przetwarzany. Pomaga oszczędzać zasoby procesora i redukować hałas w tle.",
     "Warming up... ({} blocks remaining)": "Rozgrzewanie... (pozostało {} bloków)",
     "You can also use a custom path.": "Możesz również użyć niestandardowej ścieżki.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Wsparcie](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Wsparcie](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Częstotliwość próbkowania używana do transmisji dźwięku. Zmień to, jeśli sterownik raportuje nieprawidłową częstotliwość (np. 48000 Hz zamiast 44100 Hz)."
 }

--- a/assets/i18n/languages/pt_BR.json
+++ b/assets/i18n/languages/pt_BR.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Arraste seu plugin.zip para instalá-lo",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Duração do fade entre os blocos de áudio para evitar cliques. Valores mais altos criam transições mais suaves, mas podem aumentar a latência.",
     "Embedder Model": "Modelo de Embedder",
+    "Enable ASIO": "Ativar ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Ativar o suporte ao driver ASIO. (Requer reiniciar o Applio)",
     "Enable Applio integration with Discord presence": "Habilitar integração do Applio com o status do Discord",
     "Enable VAD": "Ativar VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Habilitar deslocamento de formantes (formant shifting). Usado para conversões de masculino para feminino e vice-versa.",
@@ -134,9 +136,6 @@
     "File to Speech": "Arquivo para Fala",
     "Filter": "Filtro",
     "Folder Name": "Nome da Pasta",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Para drivers ASIO, seleciona um canal de entrada específico. Deixe em -1 para o padrão.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Para drivers ASIO, seleciona um canal de saída de monitor específico. Deixe em -1 para o padrão.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Para drivers ASIO, seleciona um canal de saída específico. Deixe em -1 para o padrão.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Para WASAPI (Windows), concede ao aplicativo controle exclusivo para uma latência potencialmente menor.",
     "Formant Shifting": "Deslocamento de Formantes",
     "Fresh Training": "Treinamento do Zero",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Ganho Molhado do Reverb",
     "Reverb Width": "Largura do Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Proteja consoantes distintas e sons de respiração para evitar distorções eletroacústicas e outros artefatos. Puxar o parâmetro para seu valor máximo de 0,5 oferece proteção abrangente. No entanto, reduzir esse valor pode diminuir a extensão da proteção, enquanto potencialmente mitiga o efeito da indexação.",
+    "Sample Rate": "Taxa de amostragem",
     "Sampling Rate": "Taxa de Amostragem",
     "Save Every Epoch": "Salvar a Cada Época",
     "Save Every Weights": "Salvar Todos os Pesos",
@@ -326,6 +326,7 @@
     "Start": "Iniciar",
     "Start Training": "Iniciar Treinamento",
     "Status": "Status",
+    "Stereo": "Estéreo",
     "Stop": "Parar",
     "Stop Training": "Parar Treinamento",
     "Stop convert": "Parar conversão",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Nível de volume abaixo do qual o áudio é tratado como silêncio e não é processado. Ajuda a economizar recursos de CPU e a reduzir o ruído de fundo.",
     "Warming up... ({} blocks remaining)": "Aquecendo... ({} blocos restantes)",
     "You can also use a custom path.": "Você também pode usar um caminho personalizado.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suporte](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suporte](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Taxa de amostragem usada para transmissão de áudio. Substitua isso se o driver reportar uma taxa incorreta (ex.: 48000 Hz em vez de 44100 Hz)."
 }

--- a/assets/i18n/languages/pt_PT.json
+++ b/assets/i18n/languages/pt_PT.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Arraste o seu plugin.zip para o instalar",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Duração do desvanecimento (fade) entre blocos de áudio para evitar estalidos. Valores mais altos criam transições mais suaves, mas podem aumentar a latência.",
     "Embedder Model": "Modelo Embedder",
+    "Enable ASIO": "Ativar ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Ativar o suporte ao controlador ASIO. (Requer o reinício do Applio)",
     "Enable Applio integration with Discord presence": "Ativar a integração do Applio com a presença no Discord",
     "Enable VAD": "Ativar VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Ativar a alteração de formantes. Usado para conversões de masculino para feminino e vice-versa.",
@@ -134,9 +136,6 @@
     "File to Speech": "Ficheiro para Fala",
     "Filter": "Filtro",
     "Folder Name": "Nome da Pasta",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Para drivers ASIO, seleciona um canal de entrada específico. Deixe em -1 para o padrão.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Para drivers ASIO, seleciona um canal de saída de monitorização específico. Deixe em -1 para o padrão.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Para drivers ASIO, seleciona um canal de saída específico. Deixe em -1 para o padrão.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Para WASAPI (Windows), concede à aplicação controlo exclusivo para uma latência potencialmente mais baixa.",
     "Formant Shifting": "Alteração de Formantes",
     "Fresh Training": "Treino do Zero",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Ganho Molhado da Reverberação",
     "Reverb Width": "Largura da Reverberação",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Proteger consoantes distintas e sons de respiração para prevenir 'tearing' eletroacústico e outros artefactos. Puxar o parâmetro para o seu valor máximo de 0.5 oferece proteção abrangente. No entanto, reduzir este valor pode diminuir o grau de proteção, mitigando potencialmente o efeito da indexação.",
+    "Sample Rate": "Taxa de amostragem",
     "Sampling Rate": "Taxa de Amostragem",
     "Save Every Epoch": "Guardar a Cada Época",
     "Save Every Weights": "Guardar Todos os Pesos",
@@ -326,6 +326,7 @@
     "Start": "Iniciar",
     "Start Training": "Iniciar Treino",
     "Status": "Estado",
+    "Stereo": "Estéreo",
     "Stop": "Parar",
     "Stop Training": "Parar Treino",
     "Stop convert": "Parar conversão",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Nível de volume abaixo do qual o áudio é tratado como silêncio e não é processado. Ajuda a poupar recursos de CPU e a reduzir o ruído de fundo.",
     "Warming up... ({} blocks remaining)": "A aquecer... ({} blocos restantes)",
     "You can also use a custom path.": "Também pode usar um caminho personalizado.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suporte](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suporte](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Taxa de amostragem utilizada para transmissão de áudio. Substitua isto se o controlador reportar uma taxa incorreta (p. ex. 48000 Hz em vez de 44100 Hz)."
 }

--- a/assets/i18n/languages/ro_RO.json
+++ b/assets/i18n/languages/ro_RO.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Trage fișierul tău plugin.zip pentru a-l instala",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Durata atenuării (fade) între fragmentele audio pentru a preveni pocnetele (clicks). Valorile mai mari creează tranziții mai line, dar pot crește latența.",
     "Embedder Model": "Model Embedder",
+    "Enable ASIO": "Activează ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Activează suportul pentru driverul ASIO. (Necesită repornirea Applio)",
     "Enable Applio integration with Discord presence": "Activează integrarea Applio cu prezența pe Discord",
     "Enable VAD": "Activează VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Activează deplasarea formanților. Folosit pentru conversii de la bărbat la femeie și invers.",
@@ -134,9 +136,6 @@
     "File to Speech": "Fișier către Voce",
     "Filter": "Filtru",
     "Folder Name": "Nume Dosar",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Pentru driverele ASIO, selectează un canal de intrare specific. Lăsați la -1 pentru valoarea implicită.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Pentru driverele ASIO, selectează un canal de ieșire specific pentru monitorizare. Lăsați la -1 pentru valoarea implicită.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Pentru driverele ASIO, selectează un canal de ieșire specific. Lăsați la -1 pentru valoarea implicită.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Pentru WASAPI (Windows), oferă aplicației control exclusiv pentru o latență potențial mai mică.",
     "Formant Shifting": "Deplasare Formanți",
     "Fresh Training": "Antrenament Nou",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Amplificare Umedă Reverberație",
     "Reverb Width": "Lățime Reverberație",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Protejează consoanele distincte și sunetele de respirație pentru a preveni distorsiunile electro-acustice și alte artefacte. Tragerea parametrului la valoarea sa maximă de 0.5 oferă protecție completă. Totuși, reducerea acestei valori ar putea diminua gradul de protecție, atenuând în același timp potențial efectul de indexare.",
+    "Sample Rate": "Frecvență de eșantionare",
     "Sampling Rate": "Rată de Eșantionare",
     "Save Every Epoch": "Salvează la Fiecare Epocă",
     "Save Every Weights": "Salvează Toate Ponderile",
@@ -326,6 +326,7 @@
     "Start": "Pornește",
     "Start Training": "Pornește Antrenamentul",
     "Status": "Stare",
+    "Stereo": "Stereo",
     "Stop": "Oprește",
     "Stop Training": "Oprește Antrenamentul",
     "Stop convert": "Oprește conversia",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Nivelul de volum sub care sunetul este tratat ca liniște și nu este procesat. Ajută la economisirea resurselor CPU și la reducerea zgomotului de fond.",
     "Warming up... ({} blocks remaining)": "Încălzire... ({} blocuri rămase)",
     "You can also use a custom path.": "Poți folosi și o cale personalizată.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suport](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Suport](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Frecvența de eșantionare utilizată pentru streaming audio. Înlocuiește aceasta dacă driverul raportează o frecvență incorectă (de ex. 48000 Hz în loc de 44100 Hz)."
 }

--- a/assets/i18n/languages/ru_RU.json
+++ b/assets/i18n/languages/ru_RU.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Перетащите ваш plugin.zip для установки",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Длительность затухания между аудиочанками для предотвращения щелчков. Более высокие значения создают более плавные переходы, но могут увеличить задержку.",
     "Embedder Model": "Модель эмбеддера",
+    "Enable ASIO": "Включить ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Включить поддержку ASIO-драйвера. (Требуется перезапуск Applio)",
     "Enable Applio integration with Discord presence": "Включить интеграцию Applio с Discord Presence",
     "Enable VAD": "Включить VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Включить формантный сдвиг. Используется для преобразования мужского голоса в женский и наоборот.",
@@ -134,9 +136,6 @@
     "File to Speech": "Файл в речь",
     "Filter": "Фильтр",
     "Folder Name": "Имя папки",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Для драйверов ASIO, выбирает определённый входной канал. Оставьте -1 для значения по умолчанию.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Для драйверов ASIO, выбирает определённый выходной канал мониторинга. Оставьте -1 для значения по умолчанию.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Для драйверов ASIO, выбирает определённый выходной канал. Оставьте -1 для значения по умолчанию.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Для WASAPI (Windows), предоставляет приложению эксклюзивный контроль для потенциально меньшей задержки.",
     "Formant Shifting": "Формантный сдвиг",
     "Fresh Training": "Обучение с нуля",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Уровень обработанного сигнала реверберации",
     "Reverb Width": "Ширина реверберации",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Защита отчётливых согласных и звуков дыхания для предотвращения электроакустических разрывов и других артефактов. Установка параметра на максимальное значение 0.5 обеспечивает всестороннюю защиту. Однако уменьшение этого значения может снизить степень защиты, потенциально ослабляя эффект индексации.",
+    "Sample Rate": "Частота дискретизации",
     "Sampling Rate": "Частота дискретизации",
     "Save Every Epoch": "Сохранять каждую эпоху",
     "Save Every Weights": "Сохранять все веса",
@@ -326,6 +326,7 @@
     "Start": "Старт",
     "Start Training": "Начать обучение",
     "Status": "Статус",
+    "Stereo": "Стерео",
     "Stop": "Стоп",
     "Stop Training": "Остановить обучение",
     "Stop convert": "Остановить конвертацию",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Уровень громкости, ниже которого аудио считается тишиной и не обрабатывается. Помогает экономить ресурсы CPU и уменьшать фоновый шум.",
     "Warming up... ({} blocks remaining)": "Прогрев... (осталось {} блоков)",
     "You can also use a custom path.": "Вы также можете использовать пользовательский путь.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Поддержка](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Поддержка](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Частота дискретизации, используемая для аудиопотока. Измените это, если драйвер сообщает неверную частоту (например, 48000 Гц вместо 44100 Гц)."
 }

--- a/assets/i18n/languages/sk_SK.json
+++ b/assets/i18n/languages/sk_SK.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Presuňte sem váš plugin.zip na inštaláciu",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Dĺžka prelínania medzi zvukovými blokmi na zabránenie praskaniu. Vyššie hodnoty vytvárajú plynulejšie prechody, ale môžu zvýšiť oneskorenie.",
     "Embedder Model": "Model embeddera",
+    "Enable ASIO": "Povoliť ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Aktivovať podporu ovládača ASIO. (Vyžaduje reštartovanie Applio)",
     "Enable Applio integration with Discord presence": "Povoliť integráciu Applio s prítomnosťou na Discorde",
     "Enable VAD": "Povoliť VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Povoliť posun formantov. Používa sa pri konverziách z mužského na ženský hlas a naopak.",
@@ -134,9 +136,6 @@
     "File to Speech": "Súbor na reč",
     "Filter": "Filter",
     "Folder Name": "Názov priečinka",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Pre ovládače ASIO, vyberá špecifický vstupný kanál. Ponechajte -1 pre predvolenú hodnotu.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Pre ovládače ASIO, vyberá špecifický výstupný kanál pre monitoring. Ponechajte -1 pre predvolenú hodnotu.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Pre ovládače ASIO, vyberá špecifický výstupný kanál. Ponechajte -1 pre predvolenú hodnotu.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Pre WASAPI (Windows), dáva aplikácii exkluzívnu kontrolu pre potenciálne nižšie oneskorenie.",
     "Formant Shifting": "Posun formantov",
     "Fresh Training": "Nové trénovanie",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Zosilnenie mokrého signálu dozvuku",
     "Reverb Width": "Šírka dozvuku",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Ochráňte zreteľné spoluhlásky a zvuky dýchania, aby ste predišli elektroakustickému trhaniu a iným artefaktom. Nastavenie parametra na maximálnu hodnotu 0,5 ponúka komplexnú ochranu. Zníženie tejto hodnoty však môže znížiť mieru ochrany, ale zároveň potenciálne zmierniť efekt indexovania.",
+    "Sample Rate": "Vzorkovacia frekvencia",
     "Sampling Rate": "Vzorkovacia frekvencia",
     "Save Every Epoch": "Ukladať každú epochu",
     "Save Every Weights": "Ukladať všetky váhy",
@@ -326,6 +326,7 @@
     "Start": "Spustiť",
     "Start Training": "Spustiť trénovanie",
     "Status": "Stav",
+    "Stereo": "Stereo",
     "Stop": "Zastaviť",
     "Stop Training": "Zastaviť trénovanie",
     "Stop convert": "Zastaviť konverziu",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Úroveň hlasitosti, pod ktorou sa zvuk považuje za ticho a nespracováva sa. Pomáha šetriť zdroje CPU a znižovať šum v pozadí.",
     "Warming up... ({} blocks remaining)": "Zahrievanie... (zostáva {} blokov)",
     "You can also use a custom path.": "Môžete použiť aj vlastnú cestu.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podpora](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Podpora](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Vzorkovacia frekvencia používaná pre audio stream. Zmeňte toto, ak ovládač hlási nesprávnu frekvenciu (napr. 48000 Hz namiesto 44100 Hz)."
 }

--- a/assets/i18n/languages/sm_SM.json
+++ b/assets/i18n/languages/sm_SM.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Toso lau plugin.zip e fa'apipi'i ai",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Le umi o le mou malie atu i le va o vaega o leo e puipuia ai ni kiliki. O tau maualuluga e fa'atupuina ai ni suiga lamolemole ae ono fa'ateleina ai le tuai.",
     "Embedder Model": "Fa'ata'ita'iga Embedder",
+    "Enable ASIO": "Fa'aagaina ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Fa'aagaina le lagolago o le ASIO driver. (E mana'omia le toe amataina o le Applio)",
     "Enable Applio integration with Discord presence": "Fa'agaoioi le tu'ufa'atasiga a le Applio ma le i ai i le Discord",
     "Enable VAD": "Fa'agaoioi le VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Fa'agaoioi le fesiita'iga o le formant. E fa'aaogaina mo le liua mai le leo o le tane i le fafine ma le fa'afeagai.",
@@ -134,9 +136,6 @@
     "File to Speech": "Faila i le Tautalaga",
     "Filter": "Faamama",
     "Folder Name": "Igoa o le faila",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Mo aveta'avale ASIO, filifili se alalaupapa fa'aulu fa'apitoa. Tu'u i le -1 mo le fa'aletonu.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Mo aveta'avale ASIO, filifili se alalaupapa mata'itū fa'apitoa e alu atu. Tu'u i le -1 mo le fa'aletonu.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Mo aveta'avale ASIO, filifili se alalaupapa fa'apitoa e alu atu. Tu'u i le -1 mo le fa'aletonu.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Mo le WASAPI (Windows), e tu'uina atu ai i le polokalama le pule fa'apitoa mo se avanoa e maualalo ai le tuai.",
     "Formant Shifting": "Fesiita'iga o le Formant",
     "Fresh Training": "A'oa'oga Fou",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Reverb Wet Gain",
     "Reverb Width": "Reverb Width",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Puipuia konesane ma'oti ma leo o le mānava e taofia ai le masaesae o le leo eletise ma isi mea sese. O le tosoina o le parameter i lona tau aupito maualuga o le 0.5 e ofoina mai ai se puipuiga atoatoa. Ae peita'i, o le fa'aitiitia o lenei tau e ono fa'aitiitia ai le lautele o le puipuiga a'o ono fa'aitiitia ai le a'afiaga o le fa'asino.",
+    "Sample Rate": "Fua o Fa'ata'ita'iga",
     "Sampling Rate": "Fua Fa'atatau o le Fa'ata'ita'iga",
     "Save Every Epoch": "Sefe i Epoch Ta'itasi",
     "Save Every Weights": "Sefe Fua Fa'atatau Uma",
@@ -326,6 +326,7 @@
     "Start": "Amata",
     "Start Training": "Amata A'oa'oga",
     "Status": "Tulaga",
+    "Stereo": "Stereo",
     "Stop": "Taofi",
     "Stop Training": "Taofi A'oa'oga",
     "Stop convert": "Taofi le liua",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Le maualuga o le leo e manatu ai o le leo o le filemu ma e le fa'agaoioia. E fesoasoani e sefe ai punaoa a le CPU ma fa'aitiitia ai le pisa i tua.",
     "Warming up... ({} blocks remaining)": "Fa'amafanafana... ({} poloka o totoe)",
     "You can also use a custom path.": "E mafai fo'i ona e fa'aaogaina se ala fa'apitoa.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Fua o fa'ata'ita'iga e fa'aogaina mo le audio streaming. Suia lenei mea pe a lipotia e le driver se fua sese (e.g. 48000 Hz nai lo 44100 Hz)."
 }

--- a/assets/i18n/languages/sr_RS.json
+++ b/assets/i18n/languages/sr_RS.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Превуците ваш plugin.zip да бисте га инсталирали",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Trajanje prelaza (fade-a) između audio blokova kako bi se sprečili klikovi. Veće vrednosti stvaraju glatkije prelaze, ali mogu povećati kašnjenje (latenciju).",
     "Embedder Model": "Модел уграђивача",
+    "Enable ASIO": "Омогући ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Омогући подршку за ASIO управљачки програм. (Захтева поновно покретање Applio-а)",
     "Enable Applio integration with Discord presence": "Омогући Applio интеграцију са Discord присуством",
     "Enable VAD": "Omogući VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Омогући померање форманта. Користи се за конверзије из мушког у женски глас и обрнуто.",
@@ -134,9 +136,6 @@
     "File to Speech": "Датотека у говор",
     "Filter": "Филтер",
     "Folder Name": "Назив фасцикле",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Za ASIO drajvere, bira određeni ulazni kanal. Ostavite na -1 za podrazumevano.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Za ASIO drajvere, bira određeni izlazni kanal za praćenje (monitoring). Ostavite na -1 za podrazumevano.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Za ASIO drajvere, bira određeni izlazni kanal. Ostavite na -1 za podrazumevano.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Za WASAPI (Windows), daje aplikaciji ekskluzivnu kontrolu radi potencijalno manjeg kašnjenja (latencije).",
     "Formant Shifting": "Померање форманта",
     "Fresh Training": "Тренирање од нуле",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Мокро појачање реверба",
     "Reverb Width": "Ширина реверба",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Заштитите изразите сугласнике и звуке дисања како бисте спречили електро-акустично кидање и друге артефакте. Повлачење параметра на максималну вредност од 0.5 нуди свеобухватну заштиту. Међутим, смањење ове вредности може смањити обим заштите, док потенцијално ублажава ефекат индексирања.",
+    "Sample Rate": "Фреквенција узорковања",
     "Sampling Rate": "Фреквенција узорковања",
     "Save Every Epoch": "Сачувај сваку епоху",
     "Save Every Weights": "Сачувај све тежине",
@@ -326,6 +326,7 @@
     "Start": "Pokreni",
     "Start Training": "Започни тренирање",
     "Status": "Status",
+    "Stereo": "Стерео",
     "Stop": "Zaustavi",
     "Stop Training": "Заустави тренирање",
     "Stop convert": "Заустави конверзију",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Nivo jačine zvuka ispod kojeg se zvuk tretira kao tišina i ne obrađuje. Pomaže u uštedi CPU resursa i smanjenju pozadinske buke.",
     "Warming up... ({} blocks remaining)": "Загревање... (преостало {} блокова)",
     "You can also use a custom path.": "Такође можете користити прилагођену путању.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Подршка](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Подршка](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Фреквенција узорковања која се користи за аудио пренос. Замените ово ако управљачки програм пријави нетачну фреквенцију (нпр. 48000 Hz умјесто 44100 Hz)."
 }

--- a/assets/i18n/languages/sw_SW.json
+++ b/assets/i18n/languages/sw_SW.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Buruta plugin.zip yako ili kuisakinisha",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Muda wa kufifisha kati ya sehemu za sauti ili kuzuia milio. Thamani za juu huleta mabadiliko laini lakini zinaweza kuongeza ucheleweshaji.",
     "Embedder Model": "Mfumo wa Kipachikaji",
+    "Enable ASIO": "Wezesha ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Wezesha msaada wa dereva wa ASIO. (Inahitaji kuanzisha upya Applio)",
     "Enable Applio integration with Discord presence": "Washa muunganisho wa Applio na uwepo wa Discord",
     "Enable VAD": "Washa VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Washa uhamishaji wa formant. Hutumika kwa ubadilishaji kutoka kwa mwanaume kwenda kwa mwanamke na kinyume chake.",
@@ -134,9 +136,6 @@
     "File to Speech": "Faili kwa Hotuba",
     "Filter": "Kichujio",
     "Folder Name": "Jina la Folda",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Kwa madereva ya ASIO, huchagua chaneli maalum ya ingizo. Acha kwa -1 kwa chaguo-msingi.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Kwa madereva ya ASIO, huchagua chaneli maalum ya tokeo la ufuatiliaji. Acha kwa -1 kwa chaguo-msingi.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Kwa madereva ya ASIO, huchagua chaneli maalum ya tokeo. Acha kwa -1 kwa chaguo-msingi.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Kwa WASAPI (Windows), huipa programu udhibiti wa kipekee kwa uwezekano wa ucheleweshaji mdogo.",
     "Formant Shifting": "Uhamishaji wa Formant",
     "Fresh Training": "Mafunzo Mapya",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Gain Lowa ya Reverb",
     "Reverb Width": "Upana wa Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Linda konsonanti tofauti na sauti za kupumua ili kuzuia mipasuko ya kielektroniki-akustisk na vizalia vingine. Kuweka kigezo kwenye thamani yake ya juu ya 0.5 kunatoa ulinzi kamili. Hata hivyo, kupunguza thamani hii kunaweza kupunguza kiwango cha ulinzi huku ukiweza kupunguza athari ya uorodheshaji.",
+    "Sample Rate": "Kiwango cha Sampuli",
     "Sampling Rate": "Kiwango cha Sampuli",
     "Save Every Epoch": "Hifadhi Kila Epoksi",
     "Save Every Weights": "Hifadhi Kila Uzito",
@@ -326,6 +326,7 @@
     "Start": "Anza",
     "Start Training": "Anza Mafunzo",
     "Status": "Hali",
+    "Stereo": "Stereo",
     "Stop": "Simamisha",
     "Stop Training": "Acha Mafunzo",
     "Stop convert": "Acha kubadilisha",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Kiwango cha sauti ambacho chini yake sauti huchukuliwa kama kimya na haichakatwi. Husaidia kuokoa rasilimali za CPU na kupunguza kelele za mandharinyuma.",
     "Warming up... ({} blocks remaining)": "Inapasha joto... (zimebaki vitalu {})",
     "You can also use a custom path.": "Unaweza pia kutumia njia maalum.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Usaidizi](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Usaidizi](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Kiwango cha sampuli kinachotumiwa kwa utiririshaji wa sauti. Badilisha hii ikiwa dereva inaripoti kiwango kisicho sahihi (mfano 48000 Hz badala ya 44100 Hz)."
 }

--- a/assets/i18n/languages/ta_IN.json
+++ b/assets/i18n/languages/ta_IN.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "உங்கள் plugin.zip கோப்பை நிறுவுவதற்கு இங்கே இழுத்து விடவும்",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "கிளிக்குகளைத் தடுக்க ஆடியோ சங்க்களுக்கு இடையேயான ஃபேடின் காலம். அதிக மதிப்புகள் மென்மையான மாற்றங்களை உருவாக்கும் ஆனால் தாமதத்தை அதிகரிக்கலாம்.",
     "Embedder Model": "எம்பெட்டர் மாடல்",
+    "Enable ASIO": "ASIO இயக்கு",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO இயக்கி ஆதரவை இயக்கு. (Applio-வை மறுதொடக்கம் செய்ய வேண்டும்)",
     "Enable Applio integration with Discord presence": "டிஸ்கார்ட் பிரசன்ஸுடன் Applio ஒருங்கிணைப்பை இயக்கு",
     "Enable VAD": "VAD-ஐ இயக்கு",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "ஃபார்மென்ட் மாற்றத்தை இயக்கு. இது ஆண் குரலை பெண் குரலாகவும், பெண் குரலை ஆண் குரலாகவும் மாற்றுவதற்குப் பயன்படுத்தப்படுகிறது.",
@@ -134,9 +136,6 @@
     "File to Speech": "கோப்பிலிருந்து பேச்சு",
     "Filter": "வடிப்பான்",
     "Folder Name": "கோப்புறையின் பெயர்",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO டிரைவர்களுக்கு, ஒரு குறிப்பிட்ட உள்ளீட்டு சேனலைத் தேர்ந்தெடுக்கிறது. இயல்புநிலைக்கு -1 என விடவும்.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO டிரைவர்களுக்கு, ஒரு குறிப்பிட்ட கண்காணிப்பு வெளியீட்டு சேனலைத் தேர்ந்தெடுக்கிறது. இயல்புநிலைக்கு -1 என விடவும்.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO டிரைவர்களுக்கு, ஒரு குறிப்பிட்ட வெளியீட்டு சேனலைத் தேர்ந்தெடுக்கிறது. இயல்புநிலைக்கு -1 என விடவும்.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) க்கு, சாத்தியமான குறைந்த தாமதத்திற்காக செயலிக்கு தனித்துவக் கட்டுப்பாட்டை வழங்குகிறது.",
     "Formant Shifting": "ஃபார்மென்ட் மாற்றம்",
     "Fresh Training": "புதிய பயிற்சி",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "ரிவெர்ப் வெட் கெய்ன்",
     "Reverb Width": "ரிவெர்ப் அகலம்",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "தனித்துவமான மெய்யெழுத்துக்கள் மற்றும் சுவாச ஒலிகளைப் பாதுகாப்பதன் மூலம் எலக்ட்ரோ-அகூஸ்டிக் கிழிசல் மற்றும் பிற கலைப்பொருட்களைத் தடுக்கவும். இந்த அளவீட்டை அதன் அதிகபட்ச மதிப்பான 0.5-க்கு இழுப்பது விரிவான பாதுகாப்பை வழங்குகிறது. இருப்பினும், இந்த மதிப்பைக் குறைப்பது பாதுகாப்பின் அளவைக் குறைக்கலாம், அதே நேரத்தில் இன்டெக்சிங் விளைவைக் குறைக்கக்கூடும்.",
+    "Sample Rate": "மாதிரி விகிதம்",
     "Sampling Rate": "மாதிரி விகிதம்",
     "Save Every Epoch": "ஒவ்வொரு சுழற்சியிலும் சேமி",
     "Save Every Weights": "ஒவ்வொரு எடைகளையும் சேமி",
@@ -326,6 +326,7 @@
     "Start": "தொடங்கு",
     "Start Training": "பயிற்சியைத் தொடங்கு",
     "Status": "நிலை",
+    "Stereo": "ஸ்டீரியோ",
     "Stop": "நிறுத்து",
     "Stop Training": "பயிற்சியை நிறுத்து",
     "Stop convert": "மாற்றுவதை நிறுத்து",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "இந்த ஒலி அளவிற்கு கீழே உள்ள ஆடியோ மௌனமாகக் கருதப்பட்டு செயலாக்கப்படாது. இது CPU வளங்களைச் சேமிக்கவும் பின்னணி இரைச்சலைக் குறைக்கவும் உதவுகிறது.",
     "Warming up... ({} blocks remaining)": "வார்ம் அப்... ({} தொகுதிகள் மீதம்)",
     "You can also use a custom path.": "நீங்கள் ஒரு தனிப்பயன் பாதையையும் பயன்படுத்தலாம்.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[ஆதரவு](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[ஆதரவு](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "ஆடியோ ஸ்ட்ரீமிங்கிற்கு பயன்படுத்தப்படும் மாதிரி விகிதம். இயக்கி தவறான விகிதத்தை தெரிவிக்கும்போது இதை மேலிடவும் (எ.கா. 44100 Hz க்கு பதிலாக 48000 Hz)."
 }

--- a/assets/i18n/languages/te_TE.json
+++ b/assets/i18n/languages/te_TE.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "దీన్ని ఇన్‌స్టాల్ చేయడానికి మీ plugin.zipని లాగండి",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "క్లిక్‌లను నివారించడానికి ఆడియో చంక్‌ల మధ్య ఫేడ్ యొక్క వ్యవధి. అధిక విలువలు సున్నితమైన మార్పులను సృష్టిస్తాయి కానీ జాప్యాన్ని పెంచవచ్చు.",
     "Embedder Model": "ఎంబెడ్డర్ మోడల్",
+    "Enable ASIO": "ASIO ని ప్రారంభించండి",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO డ్రైవర్ మద్దతును ప్రారంభించండి. (Applioను పునఃప్రారంభించడం అవసరం)",
     "Enable Applio integration with Discord presence": "Discord ప్రెజెన్స్‌తో Applio ఇంటిగ్రేషన్‌ను ప్రారంభించండి",
     "Enable VAD": "VAD ప్రారంభించు",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "ఫార్మాంట్ షిఫ్టింగ్‌ను ప్రారంభించండి. పురుషుల నుండి మహిళలకు మరియు వైస్-వర్సా మార్పిడుల కోసం ఉపయోగించబడుతుంది.",
@@ -134,9 +136,6 @@
     "File to Speech": "ఫైల్ నుండి ప్రసంగం",
     "Filter": "ఫిల్టర్",
     "Folder Name": "ఫోల్డర్ పేరు",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO డ్రైవర్ల కోసం, ఒక నిర్దిష్ట ఇన్‌పుట్ ఛానెల్‌ను ఎంచుకుంటుంది. డిఫాల్ట్ కోసం -1 వద్ద వదిలివేయండి.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO డ్రైవర్ల కోసం, ఒక నిర్దిష్ట మానిటర్ అవుట్‌పుట్ ఛానెల్‌ను ఎంచుకుంటుంది. డిఫాల్ట్ కోసం -1 వద్ద వదిలివేయండి.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO డ్రైవర్ల కోసం, ఒక నిర్దిష్ట అవుట్‌పుట్ ఛానెల్‌ను ఎంచుకుంటుంది. డిఫాల్ట్ కోసం -1 వద్ద వదిలివేయండి.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) కోసం, తక్కువ జాప్యం కోసం యాప్‌కు ప్రత్యేక నియంత్రణను ఇస్తుంది.",
     "Formant Shifting": "ఫార్మాంట్ షిఫ్టింగ్",
     "Fresh Training": "తాజా శిక్షణ",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "రెవెర్బ్ వెట్ గెయిన్",
     "Reverb Width": "రెవెర్బ్ వెడల్పు",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "ఎలక్ట్రో-అకౌస్టిక్ టియరింగ్ మరియు ఇతర ఆర్టిఫ్యాక్ట్‌లను నివారించడానికి విభిన్న హల్లులు మరియు శ్వాస శబ్దాలను కాపాడండి. పారామీటర్‌ను దాని గరిష్ట విలువ 0.5కి లాగడం సమగ్ర రక్షణను అందిస్తుంది. అయితే, ఈ విలువను తగ్గించడం వల్ల రక్షణ పరిధిని తగ్గించవచ్చు మరియు ఇండెక్సింగ్ ప్రభావాన్ని తగ్గించవచ్చు.",
+    "Sample Rate": "శాంపిల్ రేట్",
     "Sampling Rate": "నమూనా రేటు",
     "Save Every Epoch": "ప్రతి ఎపోక్‌లో సేవ్ చేయండి",
     "Save Every Weights": "ప్రతి వెయిట్స్‌ను సేవ్ చేయండి",
@@ -326,6 +326,7 @@
     "Start": "ప్రారంభించు",
     "Start Training": "శిక్షణను ప్రారంభించండి",
     "Status": "స్థితి",
+    "Stereo": "స్టీరియో",
     "Stop": "ఆపు",
     "Stop Training": "శిక్షణను ఆపండి",
     "Stop convert": "మార్పిడిని ఆపండి",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "ఏ వాల్యూమ్ స్థాయి కంటే తక్కువ ఉన్న ఆడియో నిశ్శబ్దంగా పరిగణించబడుతుంది మరియు ప్రాసెస్ చేయబడదు. ఇది CPU వనరులను ఆదా చేయడానికి మరియు నేపథ్య శబ్దాన్ని తగ్గించడానికి సహాయపడుతుంది.",
     "Warming up... ({} blocks remaining)": "వార్మింగ్ అప్... ({} బ్లాక్‌లు మిగిలి ఉన్నాయి)",
     "You can also use a custom path.": "మీరు అనుకూల మార్గాన్ని కూడా ఉపయోగించవచ్చు.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[మద్దతు](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[మద్దతు](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "ఆడియో స్ట్రీమింగ్‌కు ఉపయోగించే శాంపిల్ రేట్. డ్రైవర్ తప్పుడు రేట్ నివేదిస్తే దీన్ని ఓవర్‌రైడ్ చేయండి (ఉదా. 44100 Hz బదులు 48000 Hz)."
 }

--- a/assets/i18n/languages/th_TH.json
+++ b/assets/i18n/languages/th_TH.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "ลากไฟล์ plugin.zip ของคุณมาเพื่อติดตั้ง",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "ระยะเวลาของการเฟดระหว่างชิ้นส่วนเสียงเพื่อป้องกันเสียงคลิก ค่าที่สูงขึ้นจะทำให้การเปลี่ยนเสียงราบรื่นขึ้นแต่อาจเพิ่มความหน่วงแฝง",
     "Embedder Model": "โมเดล Embedder",
+    "Enable ASIO": "เปิดใช้งาน ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "เปิดใช้งานการรองรับไดรเวอร์ ASIO เลือกอุปกรณ์ ASIO เป็นอินพุต/เอาต์พุต และตั้งค่าหมายเลขช่องสัญญาณด้านบน ต้องรีสตาร์ท Applio เพื่อให้การเปลี่ยนแปลงมีผล(ต้องรีสตาร์ท Applio)",
     "Enable Applio integration with Discord presence": "เปิดใช้งานการเชื่อมต่อ Applio กับสถานะ Discord",
     "Enable VAD": "เปิดใช้งาน VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "เปิดใช้งานการเลื่อนฟอร์แมนต์ (formant shifting) ใช้สำหรับการแปลงเสียงชายเป็นหญิงและกลับกัน",
@@ -134,9 +136,6 @@
     "File to Speech": "ไฟล์เป็นเสียงพูด",
     "Filter": "ตัวกรอง",
     "Folder Name": "ชื่อโฟลเดอร์",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "สำหรับไดรเวอร์ ASIO ใช้เลือกช่องสัญญาณอินพุตเฉพาะ หากไม่ต้องการระบุให้ใช้ค่า -1 (ค่าเริ่มต้น)",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "สำหรับไดรเวอร์ ASIO ใช้เลือกช่องสัญญาณเอาต์พุตมอนิเตอร์เฉพาะ หากไม่ต้องการระบุให้ใช้ค่า -1 (ค่าเริ่มต้น)",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "สำหรับไดรเวอร์ ASIO ใช้เลือกช่องสัญญาณเอาต์พุตเฉพาะ หากไม่ต้องการระบุให้ใช้ค่า -1 (ค่าเริ่มต้น)",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "สำหรับ WASAPI (Windows) จะให้แอปควบคุมอุปกรณ์ได้โดยเฉพาะ ซึ่งอาจช่วยลดความหน่วงแฝงได้",
     "Formant Shifting": "การเลื่อนฟอร์แมนต์ (Formant Shifting)",
     "Fresh Training": "การฝึกใหม่ทั้งหมด",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Reverb Wet Gain",
     "Reverb Width": "ความกว้าง Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "ป้องกันเสียงพยัญชนะและเสียงลมหายใจที่ชัดเจนเพื่อป้องกันการฉีกขาดของเสียงและสิ่งแปลกปลอมอื่นๆ การดึงพารามิเตอร์ไปที่ค่าสูงสุด 0.5 จะให้การป้องกันที่ครอบคลุม อย่างไรก็ตาม การลดค่านี้อาจลดระดับการป้องกันในขณะที่อาจลดผลกระทบของดัชนี (indexing effect) ลงได้",
+    "Sample Rate": "อัตราการสุ่มตัวอย่าง",
     "Sampling Rate": "อัตราการสุ่มตัวอย่าง (Sampling Rate)",
     "Save Every Epoch": "บันทึกทุก Epoch",
     "Save Every Weights": "บันทึกน้ำหนัก (Weights) ทุกครั้ง",
@@ -326,6 +326,7 @@
     "Start": "เริ่ม",
     "Start Training": "เริ่มการฝึก",
     "Status": "สถานะ",
+    "Stereo": "สเตอริโอ",
     "Stop": "หยุด",
     "Stop Training": "หยุดการฝึก",
     "Stop convert": "หยุดการแปลง",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "ระดับเสียงที่ต่ำกว่าเกณฑ์นี้จะถูกนับเป็นความเงียบและจะไม่ถูกประมวลผล ช่วยประหยัดทรัพยากร CPU และลดเสียงรบกวน",
     "Warming up... ({} blocks remaining)": "กำลังอุ่นเครื่อง... (เหลืออีก {} บล็อก)",
     "You can also use a custom path.": "คุณสามารถใช้เส้นทางที่กำหนดเองได้เช่นกัน",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[สนับสนุน](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[สนับสนุน](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "อัตราการสุ่มตัวอย่างที่ใช้สำหรับการสตรีมเสียง เปลี่ยนค่านี้หากไดรเวอร์รายงานอัตราที่ไม่ถูกต้อง (เช่น 48000 Hz แทน 44100 Hz)"
 }

--- a/assets/i18n/languages/to_TO.json
+++ b/assets/i18n/languages/to_TO.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Toho mai hoʻo plugin.zip ke fola ia",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Ko e lōloa ʻo e mole māmālie ʻi he vahaʻa ʻo e ngaahi konga ongo ke taʻofi e ngaahi patapatá. Ko e mahuʻinga māʻolungá ʻokú ne fakatupu ha ngaahi liliu molū ange ka ʻe lava ke ne fakaʻāsili e toloí.",
     "Embedder Model": "Mōtele Embedder",
+    "Enable ASIO": "Fakamālō ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Fakamālō tokoni ki he ASIO driver. (ʻOku fiemaʻu ke toe kamataʻi ʻa e Applio)",
     "Enable Applio integration with Discord presence": "Fakangofua ʻa e fehokotaki ʻa e Applio mo e ʻi ai ʻa e Discord",
     "Enable VAD": "Fakangofua e VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Fakangofua ʻa e liliu ʻo e formant. Ngāueʻaki ki he liliu mei he tangata ki he fefine pea pehē foki ki mui.",
@@ -134,9 +136,6 @@
     "File to Speech": "Faile ki he Lea",
     "Filter": "Filtre",
     "Folder Name": "Hingoa ʻo e Tōʻanga Faile",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Ki he kau fakaʻuli ʻa e ASIO, fili ha senolo huʻu pau. Tuku ia ʻi he -1 ki he tuʻunga angamahení.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Ki he kau fakaʻuli ʻa e ASIO, fili ha senolo ʻaútiputi fakaʻaliʻali pau. Tuku ia ʻi he -1 ki he tuʻunga angamahení.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Ki he kau fakaʻuli ʻa e ASIO, fili ha senolo ʻaútiputi pau. Tuku ia ʻi he -1 ki he tuʻunga angamahení.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Ki he WASAPI (Windows), ʻokú ne ʻoange ki he polokalamá ha mafai fakaʻataʻatā ke fakasiʻisiʻi e toloí.",
     "Formant Shifting": "Liliu ʻo e Formant",
     "Fresh Training": "Ako Foʻou",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Tupu ʻAʻau ʻo e Reverb",
     "Reverb Width": "Fālahinga ʻo e Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Maluʻi ʻa e ngaahi konisonanite makehe mo e ngaahi ongo mānavá ke taʻofi ʻa e mahae fakaʻilekitulōnika-fakaongo mo e ngaahi meʻa kehe. Ko hono toho ʻo e fakangatangatá ki hono tuʻunga māʻolunga taha ʻo e 0.5 ʻokú ne ʻomi ha maluʻi kakato. Kae kehe, ko hono fakasiʻisiʻi ʻo e mahuʻinga ko ʻení ʻe lava ke ne fakasiʻisiʻi ai ʻa e tuʻunga maluʻí kae malava ke ne fakasiʻisiʻi ai ʻa e ola ʻo e ʻinitekisí.",
+    "Sample Rate": "Fua Tauhi",
     "Sampling Rate": "Tuʻunga ʻo e Sampling",
     "Save Every Epoch": "Seivi ʻa e Epoch Kotoa Pē",
     "Save Every Weights": "Seivi ʻa e Mamafa Kotoa Pē",
@@ -326,6 +326,7 @@
     "Start": "Kamata",
     "Start Training": "Kamataʻi ʻa e Ako",
     "Status": "Tuʻunga",
+    "Stereo": "Stereo",
     "Stop": "Taʻofi",
     "Stop Training": "Tuku ʻa e Ako",
     "Stop convert": "Tuku ʻa e Liliu",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Ko e tuʻunga ʻo e leʻó ʻa ia ʻoku lau ai ʻa e ongo ʻi laló ko e fakalongolongo pea ʻikai ngāueʻi. ʻOkú ne tokoni ke hao ai e ngaahi maʻuʻanga ivi ʻo e CPU pea fakasiʻisiʻi e longoaʻa ʻi tuʻá.",
     "Warming up... ({} blocks remaining)": "Fakamafana... ({} poloka kei toe)",
     "You can also use a custom path.": "ʻE lava foki ke ke ngāueʻaki ha hala fakafoʻituitui.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Tokoni](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Tokoni](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Ko e fua tauhi ʻoku ngāue ʻaki ki he audio streaming. Liliu eni kapau ʻoku lipooti ʻe he driver ha fua hala (e.g. 48000 Hz ʻi hono ʻo 44100 Hz)."
 }

--- a/assets/i18n/languages/tr_TR.json
+++ b/assets/i18n/languages/tr_TR.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Eklentiyi yüklemek için plugin.zip dosyanızı sürükleyin",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Tıklamaları önlemek için ses yığınları arasındaki geçişin süresi. Daha yüksek değerler daha pürüzsüz geçişler oluşturur ancak gecikmeyi artırabilir.",
     "Embedder Model": "Gömücü Modeli",
+    "Enable ASIO": "ASIO'yu etkinleştir",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO sürücü desteğini etkinleştir. (Applio'nun yeniden başlatılmasını gerektirir)",
     "Enable Applio integration with Discord presence": "Applio'nun Discord aktivite durumu entegrasyonunu etkinleştir",
     "Enable VAD": "VAD'ı Etkinleştir",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Formant kaydırmayı etkinleştirin. Erkekten kadına ve tersi dönüşümler için kullanılır.",
@@ -134,9 +136,6 @@
     "File to Speech": "Dosyadan Konuşmaya",
     "Filter": "Filtre",
     "Folder Name": "Klasör Adı",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO sürücüleri için belirli bir giriş kanalını seçer. Varsayılan için -1'de bırakın.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO sürücüleri için belirli bir monitör çıkış kanalını seçer. Varsayılan için -1'de bırakın.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO sürücüleri için belirli bir çıkış kanalını seçer. Varsayılan için -1'de bırakın.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (Windows) için, potansiyel olarak daha düşük gecikme için uygulamaya özel denetim verir.",
     "Formant Shifting": "Formant Kaydırma",
     "Fresh Training": "Sıfırdan Eğitim",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Yankı Islak Kazanç",
     "Reverb Width": "Yankı Genişliği",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Elektro-akustik yırtılmayı ve diğer yapaylıkları önlemek için belirgin ünsüzleri ve nefes seslerini koruyun. Parametreyi maksimum 0.5 değerine çekmek kapsamlı koruma sağlar. Ancak, bu değeri düşürmek koruma derecesini azaltabilirken potansiyel olarak indeksleme etkisini hafifletebilir.",
+    "Sample Rate": "Örnekleme Hızı",
     "Sampling Rate": "Örnekleme Hızı",
     "Save Every Epoch": "Her Epokta Kaydet",
     "Save Every Weights": "Her Ağırlığı Kaydet",
@@ -326,6 +326,7 @@
     "Start": "Başlat",
     "Start Training": "Eğitimi Başlat",
     "Status": "Durum",
+    "Stereo": "Stereo",
     "Stop": "Durdur",
     "Stop Training": "Eğitimi Durdur",
     "Stop convert": "Dönüştürmeyi durdur",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Sesin sessizlik olarak kabul edildiği ve işlenmediği ses seviyesi. CPU kaynaklarından tasarruf etmeye ve arka plan gürültüsünü azaltmaya yardımcı olur.",
     "Warming up... ({} blocks remaining)": "Isınıyor... ({} blok kaldı)",
     "You can also use a custom path.": "Ayrıca özel bir yol da kullanabilirsiniz.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Destek](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Destek](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Ses akışı için kullanılan örnekleme hızı. Sürücü yanlış bir hız bildirirse bunu geçersiz kıl (örn. 44100 Hz yerine 48000 Hz)."
 }

--- a/assets/i18n/languages/uk_UK.json
+++ b/assets/i18n/languages/uk_UK.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Перетягніть ваш plugin.zip, щоб встановити його",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Тривалість затухання між аудіочанками для запобігання клацанням. Вищі значення створюють плавніші переходи, але можуть збільшити затримку.",
     "Embedder Model": "Модель ембедера",
+    "Enable ASIO": "Увімкнути ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Увімкнути підтримку драйвера ASIO. (Потребує перезапуску Applio)",
     "Enable Applio integration with Discord presence": "Увімкнути інтеграцію Applio з Discord presence",
     "Enable VAD": "Увімкнути VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Увімкнути зсув формант. Використовується для перетворень з чоловічого голосу в жіночий і навпаки.",
@@ -134,9 +136,6 @@
     "File to Speech": "Файл у мовлення",
     "Filter": "Фільтр",
     "Folder Name": "Назва теки",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Для драйверів ASIO, вибирає конкретний вхідний канал. Залиште -1 для значення за замовчуванням.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Для драйверів ASIO, вибирає конкретний вихідний канал моніторингу. Залиште -1 для значення за замовчуванням.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Для драйверів ASIO, вибирає конкретний вихідний канал. Залиште -1 для значення за замовчуванням.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Для WASAPI (Windows), надає програмі ексклюзивний контроль для потенційно меншої затримки.",
     "Formant Shifting": "Зсув формант",
     "Fresh Training": "Нове тренування",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Мокре підсилення реверберації",
     "Reverb Width": "Ширина реверберації",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Захист чітких приголосних та звуків дихання для запобігання електроакустичним розривам та іншим артефактам. Встановлення параметра на максимальне значення 0.5 забезпечує комплексний захист. Однак, зменшення цього значення може знизити рівень захисту, потенційно зменшуючи ефект індексації.",
+    "Sample Rate": "Частота дискретизації",
     "Sampling Rate": "Частота дискретизації",
     "Save Every Epoch": "Зберігати кожну епоху",
     "Save Every Weights": "Зберігати кожні ваги",
@@ -326,6 +326,7 @@
     "Start": "Старт",
     "Start Training": "Почати тренування",
     "Status": "Статус",
+    "Stereo": "Стерео",
     "Stop": "Стоп",
     "Stop Training": "Зупинити тренування",
     "Stop convert": "Зупинити конвертацію",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Рівень гучності, нижче якого аудіо вважається тишею і не обробляється. Допомагає заощаджувати ресурси ЦП та зменшувати фоновий шум.",
     "Warming up... ({} blocks remaining)": "Прогрів... (залишилось {} блоків)",
     "You can also use a custom path.": "Ви також можете використовувати власний шлях.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Підтримка](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Підтримка](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Частота дискретизації, що використовується для аудіопотоку. Змініть це, якщо драйвер повідомляє неправильну частоту (наприклад, 48000 Гц замість 44100 Гц)."
 }

--- a/assets/i18n/languages/ur_UR.json
+++ b/assets/i18n/languages/ur_UR.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "اسے انسٹال کرنے کے لیے اپنی plugin.zip کو گھسیٹیں",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "کلکس کو روکنے کے لیے آڈیو چنکس کے درمیان فیڈ کا دورانیہ۔ اعلیٰ اقدار ہموار منتقلی پیدا کرتی ہیں لیکن تاخیر میں اضافہ کر سکتی ہیں۔",
     "Embedder Model": "ایمبیڈر ماڈل",
+    "Enable ASIO": "ASIO فعال کریں",
+    "Enable ASIO driver support. (Requires restarting Applio)": "ASIO ڈرائیور سپورٹ فعال کریں۔ ASIO ڈیوائس کو ان پٹ/آؤٹ پٹ کے طور پر منتخب کریں اور اوپر چینل نمبر سیٹ کریں۔ تبدیلیاں نافذ کرنے کے لیے Applio کو دوبارہ شروع کرنا ضروری ہے۔(Applio کو دوبارہ شروع کرنے کی ضرورت ہے)",
     "Enable Applio integration with Discord presence": "ڈسکارڈ موجودگی کے ساتھ Applio انٹیگریشن کو فعال کریں",
     "Enable VAD": "VAD کو فعال کریں",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "فارمینٹ شفٹنگ کو فعال کریں۔ مرد سے عورت اور اس کے برعکس تبدیلیوں کے لیے استعمال ہوتا ہے۔",
@@ -134,9 +136,6 @@
     "File to Speech": "فائل سے تقریر",
     "Filter": "فلٹر",
     "Folder Name": "فولڈر کا نام",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "ASIO ڈرائیورز کے لیے، ایک مخصوص ان پٹ چینل منتخب کرتا ہے۔ ڈیفالٹ کے لیے -1 پر چھوڑ دیں۔",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "ASIO ڈرائیورز کے لیے، ایک مخصوص مانیٹر آؤٹ پٹ چینل منتخب کرتا ہے۔ ڈیفالٹ کے لیے -1 پر چھوڑ دیں۔",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "ASIO ڈرائیورز کے لیے، ایک مخصوص آؤٹ پٹ چینل منتخب کرتا ہے۔ ڈیفالٹ کے لیے -1 پر چھوڑ دیں۔",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "WASAPI (ونڈوز) کے لیے، ممکنہ طور پر کم تاخیر کے لیے ایپ کو خصوصی کنٹرول دیتا ہے۔",
     "Formant Shifting": "فارمینٹ شفٹنگ",
     "Fresh Training": "نئی تربیت",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "ریورب ویٹ گین",
     "Reverb Width": "ریورب وڈتھ",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "الیکٹرو-اکوسٹک پھاڑ اور دیگر نقائص کو روکنے کے لیے مخصوص حروف صحیح اور سانس کی آوازوں کی حفاظت کریں۔ پیرامیٹر کو اس کی زیادہ سے زیادہ قیمت 0.5 تک کھینچنا جامع تحفظ فراہم کرتا ہے۔ تاہم، اس قیمت کو کم کرنے سے تحفظ کی حد کم ہو سکتی ہے جبکہ ممکنہ طور پر انڈیکسنگ اثر کو کم کیا جا سکتا ہے۔",
+    "Sample Rate": "سیمپل ریٹ",
     "Sampling Rate": "نمونے لینے کی شرح",
     "Save Every Epoch": "ہر دور (epoch) کو محفوظ کریں",
     "Save Every Weights": "ہر وزن کو محفوظ کریں",
@@ -326,6 +326,7 @@
     "Start": "شروع کریں",
     "Start Training": "تربیت شروع کریں",
     "Status": "اسٹیٹس",
+    "Stereo": "سٹیریو",
     "Stop": "روکیں",
     "Stop Training": "تربیت روکیں",
     "Stop convert": "تبدیلی روکیں",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "والیوم کی سطح جس سے نیچے آڈیو کو خاموشی سمجھا جاتا ہے اور اس پر کارروائی نہیں ہوتی۔ یہ CPU وسائل کو بچانے اور پس منظر کے شور کو کم کرنے میں مدد کرتا ہے۔",
     "Warming up... ({} blocks remaining)": "وارم اپ... ({} بلاکس باقی)",
     "You can also use a custom path.": "آپ کسٹم راستہ بھی استعمال کر سکتے ہیں۔",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[سپورٹ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[سپورٹ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "آڈیو سٹریمنگ کے لیے استعمال ہونے والا سیمپل ریٹ۔ اگر ڈرائیور غلط ریٹ رپورٹ کرے تو اسے تبدیل کریں (مثلاً 44100 Hz کی بجائے 48000 Hz)۔"
 }

--- a/assets/i18n/languages/vi_VI.json
+++ b/assets/i18n/languages/vi_VI.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Kéo tệp plugin.zip của bạn để cài đặt",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "Thời lượng mờ dần giữa các đoạn âm thanh để ngăn tiếng lách cách. Giá trị cao hơn tạo ra chuyển tiếp mượt mà hơn nhưng có thể làm tăng độ trễ.",
     "Embedder Model": "Mô hình Embedder",
+    "Enable ASIO": "Bật ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "Bật hỗ trợ driver ASIO. (Yêu cầu khởi động lại Applio)",
     "Enable Applio integration with Discord presence": "Bật tích hợp Applio với trạng thái Discord",
     "Enable VAD": "Bật VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Bật dịch chuyển formant. Dùng cho việc chuyển đổi giọng nam sang nữ và ngược lại.",
@@ -134,9 +136,6 @@
     "File to Speech": "Tệp sang Lời nói",
     "Filter": "Bộ lọc",
     "Folder Name": "Tên Thư mục",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "Đối với trình điều khiển ASIO, chọn một kênh đầu vào cụ thể. Để ở -1 để dùng mặc định.",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "Đối với trình điều khiển ASIO, chọn một kênh đầu ra giám sát (monitor) cụ thể. Để ở -1 để dùng mặc định.",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "Đối với trình điều khiển ASIO, chọn một kênh đầu ra cụ thể. Để ở -1 để dùng mặc định.",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "Đối với WASAPI (Windows), cấp cho ứng dụng quyền kiểm soát độc quyền để có thể giảm độ trễ.",
     "Formant Shifting": "Dịch chuyển Formant",
     "Fresh Training": "Huấn luyện Mới",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Độ khuếch đại ướt Reverb",
     "Reverb Width": "Độ rộng Reverb",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Bảo vệ các phụ âm riêng biệt và âm thanh hơi thở để ngăn chặn hiện tượng xé âm thanh điện và các tạp âm khác. Kéo tham số lên giá trị tối đa 0.5 sẽ cung cấp sự bảo vệ toàn diện. Tuy nhiên, việc giảm giá trị này có thể làm giảm mức độ bảo vệ nhưng có khả năng giảm thiểu hiệu ứng chỉ mục hóa.",
+    "Sample Rate": "Tần số lấy mẫu",
     "Sampling Rate": "Tốc độ Lấy mẫu",
     "Save Every Epoch": "Lưu mỗi Epoch",
     "Save Every Weights": "Lưu mỗi Trọng số",
@@ -326,6 +326,7 @@
     "Start": "Bắt đầu",
     "Start Training": "Bắt đầu Huấn luyện",
     "Status": "Trạng thái",
+    "Stereo": "Âm thanh nổi",
     "Stop": "Dừng",
     "Stop Training": "Dừng Huấn luyện",
     "Stop convert": "Dừng chuyển đổi",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "Mức âm lượng mà dưới đó âm thanh được coi là tĩnh lặng và không được xử lý. Giúp tiết kiệm tài nguyên CPU và giảm tiếng ồn nền.",
     "Warming up... ({} blocks remaining)": "Đang khởi động... (còn {} khối)",
     "You can also use a custom path.": "Bạn cũng có thể sử dụng một đường dẫn tùy chỉnh.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Hỗ trợ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Hỗ trợ](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "Tần số lấy mẫu được sử dụng cho phát trực tiếp âm thanh. Ghi đè điều này nếu driver báo tốc độ không chính xác (ví dụ 48000 Hz thay vì 44100 Hz)."
 }

--- a/assets/i18n/languages/wu_WU.json
+++ b/assets/i18n/languages/wu_WU.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "Drag your plugin.zip to install it",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "音频区块之间淡化个持续辰光，防止咔哒声。较高个值可以创建更平滑个过渡，但可能会增加延迟。",
     "Embedder Model": "Wumbo-bedder Wumbodel",
+    "Enable ASIO": "启用 ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "启用 ASIO 驱动程序支持。(Requires restarting Applio)",
     "Enable Applio integration with Discord presence": "Wumbo-on Applio integration with Discord presence",
     "Enable VAD": "启用 VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "Wumbo-on formant shifting. Used for male to female and vice-versa wumbifications.",
@@ -134,9 +136,6 @@
     "File to Speech": "Wumbofile to Speech",
     "Filter": "Фильтр",
     "Folder Name": "Folder Name",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "对ASIO驱动程序，选择特定个输入通道。保留-1为默认值。",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "对ASIO驱动程序，选择特定个监听输出通道。保留-1为默认值。",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "对ASIO驱动程序，选择特定个输出通道。保留-1为默认值。",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "对WASAPI（Windows），畀应用程序独占控制权，以可能降低延迟。",
     "Formant Shifting": "Formant Shifting",
     "Fresh Training": "Fresh Wumboing",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "Wumbo-verb Wet Gain",
     "Reverb Width": "Wumbo-verb Width",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the wumbo-dexing effect.",
+    "Sample Rate": "采样率",
     "Sampling Rate": "Sampling Rate",
     "Save Every Epoch": "Wumbo-keep Every Epoch",
     "Save Every Weights": "Wumbo-keep Every Weights",
@@ -326,6 +326,7 @@
     "Start": "开始",
     "Start Training": "Start Wumboing",
     "Status": "状态",
+    "Stereo": "立体声",
     "Stop": "停止",
     "Stop Training": "Stop Wumboing",
     "Stop convert": "Stop wumbify",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "低于该音量个音频将被视为静音而弗处理。有助于节省CPU资源并减少背景噪音。",
     "Warming up... ({} blocks remaining)": "预热中... (还剩 {} 个块)",
     "You can also use a custom path.": "You can also use a custom wumbopath.",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "用于音频流传输的采样率。如果驱动程序报告的采样率不正确（例如 48000 Hz 而非 44100 Hz），请在此处覆盖。"
 }

--- a/assets/i18n/languages/zh_CN.json
+++ b/assets/i18n/languages/zh_CN.json
@@ -100,6 +100,8 @@
     "Drag your plugin.zip to install it": "拖动您的 plugin.zip 文件以进行安装",
     "Duration of the fade between audio chunks to prevent clicks. Higher values create smoother transitions but may increase latency.": "音频块之间交叉淡化的持续时间，以防止产生咔哒声。值越高过渡越平滑，但可能会增加延迟。",
     "Embedder Model": "嵌入器模型",
+    "Enable ASIO": "启用 ASIO",
+    "Enable ASIO driver support. (Requires restarting Applio)": "启用 ASIO 驱动程序支持。（需要重启 Applio）",
     "Enable Applio integration with Discord presence": "启用 Applio 与 Discord 状态的集成",
     "Enable VAD": "启用 VAD",
     "Enable formant shifting. Used for male to female and vice-versa convertions.": "启用共振峰移位。用于男声转女声或女声转男声的转换。",
@@ -134,9 +136,6 @@
     "File to Speech": "文件转语音",
     "Filter": "过滤器",
     "Folder Name": "文件夹名称",
-    "For ASIO drivers, selects a specific input channel. Leave at -1 for default.": "用于 ASIO 驱动，选择一个特定的输入通道。保留 -1 为默认值。",
-    "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default.": "用于 ASIO 驱动，选择一个特定的监听输出通道。保留 -1 为默认值。",
-    "For ASIO drivers, selects a specific output channel. Leave at -1 for default.": "用于 ASIO 驱动，选择一个特定的输出通道。保留 -1 为默认值。",
     "For WASAPI (Windows), gives the app exclusive control for potentially lower latency.": "用于 WASAPI (Windows)，授予应用独占控制权以可能降低延迟。",
     "Formant Shifting": "共振峰移位",
     "Fresh Training": "全新训练",
@@ -254,6 +253,7 @@
     "Reverb Wet Gain": "混响湿声增益",
     "Reverb Width": "混响宽度",
     "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect.": "保护独特的辅音和呼吸声，以防止电声撕裂和其他杂音。将参数拉到最大值 0.5 可提供全面保护。然而，降低此值可能会减少保护程度，但可能减轻索引效应。",
+    "Sample Rate": "采样率",
     "Sampling Rate": "采样率",
     "Save Every Epoch": "每轮都保存",
     "Save Every Weights": "保存每个权重",
@@ -326,6 +326,7 @@
     "Start": "开始",
     "Start Training": "开始训练",
     "Status": "状态",
+    "Stereo": "立体声",
     "Stop": "停止",
     "Stop Training": "停止训练",
     "Stop convert": "停止转换",
@@ -373,5 +374,6 @@
     "Volume level below which audio is treated as silence and not processed. Helps to save CPU resources and reduce background noise.": "低于此音量级别的音频将被视为静音且不作处理。这有助于节省 CPU 资源并减少背景噪音。",
     "Warming up... ({} blocks remaining)": "预热中... (还剩 {} 个块)",
     "You can also use a custom path.": "您也可以使用自定义路径。",
-    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[支持](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)"
+    "[Support](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)": "[支持](https://discord.gg/urxFjYmYYh) — [GitHub](https://github.com/IAHispano/Applio)",
+    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values.": "用于音频流传输的采样率。如果驱动程序报告的采样率不正确（例如 48000 Hz 而非 44100 Hz），请在此处覆盖。"
 }

--- a/rvc/lib/platform.py
+++ b/rvc/lib/platform.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 import platform
 
 
@@ -7,3 +8,13 @@ def platform_config():
     if sys.platform == "darwin" and platform.machine() == "arm64":
         os.environ["OMP_NUM_THREADS"] = "1"
         os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
+
+    if sys.platform == "win32":
+        try:
+            config_path = os.path.join(os.getcwd(), "assets", "config.json")
+            with open(config_path, "r", encoding="utf-8") as f:
+                config = json.load(f)
+            if config.get("realtime", {}).get("asio_enabled", False):
+                os.environ["SD_ENABLE_ASIO"] = "1"
+        except Exception:
+            pass

--- a/rvc/realtime/audio.py
+++ b/rvc/realtime/audio.py
@@ -390,9 +390,7 @@ class Audio:
                 if asio_output_stereo
                 else [asio_output_channel]
             )
-            output_extra_setting = sd.AsioSettings(
-                channel_selectors=output_selectors
-            )
+            output_extra_setting = sd.AsioSettings(channel_selectors=output_selectors)
             output_channels = len(output_selectors)
 
         if self.use_monitor:
@@ -414,7 +412,9 @@ class Audio:
                 )
                 monitor_channels = 1
 
-        block_frame = int((read_chunk_size * 128 / AUDIO_SAMPLE_RATE) * audio_sample_rate)
+        block_frame = int(
+            (read_chunk_size * 128 / AUDIO_SAMPLE_RATE) * audio_sample_rate
+        )
 
         try:
             self.run_audio_stream(

--- a/rvc/realtime/audio.py
+++ b/rvc/realtime/audio.py
@@ -27,16 +27,10 @@ def check_the_device(device, type: str = "input"):
     if sys.platform == "linux" and "hw:" not in device["name"]:
         return False
 
-    stream_cls = sd.InputStream if type == "input" else sd.OutputStream
-    try:
-        with stream_cls(
-            device=device["index"],
-            dtype=np.float32,
-            samplerate=device["default_samplerate"],
-        ):
-            return True
-    except Exception:
-        return False
+    if type == "input":
+        return device["max_input_channels"] > 0
+    else:
+        return device["max_output_channels"] > 0
 
 
 def list_audio_device():
@@ -100,6 +94,27 @@ def list_audio_device():
         audio_output_device.append(output_audio_device)
 
     return audio_input_device, audio_output_device
+
+
+def resolve_sample_rate(
+    input_device_id: int,
+    asio_enabled: bool,
+    audio_sample_rate: int,
+) -> int:
+    """Return the sample rate to use for audio streaming.
+
+    For ASIO the user-selected rate is used as-is because ASIO drivers
+    do not expose a reliable default_samplerate via PortAudio.
+    For all other host APIs the input device's default_samplerate is used
+    so that the stream matches the rate the OS/driver actually operates at.
+    """
+    if asio_enabled:
+        return audio_sample_rate
+    try:
+        device = sd.query_devices(input_device_id)
+        return int(device["default_samplerate"])
+    except Exception:
+        return audio_sample_rate
 
 
 class Audio:
@@ -232,7 +247,18 @@ class Audio:
         input_extra_setting,
         output_extra_setting,
         output_monitor_extra_setting,
+        audio_sample_rate: int,
     ):
+        use_asio = isinstance(input_extra_setting, sd.AsioSettings) or isinstance(
+            output_extra_setting, sd.AsioSettings
+        )
+        if use_asio:
+            # Re-initialize PortAudio to ensure a clean ASIO driver state.
+            try:
+                sd._terminate()
+                sd._initialize()
+            except Exception:
+                pass
         if input_device_id != output_device_id:
             # Only use in cases involving different backends devices.
             self.input_stream = sd.InputStream(
@@ -241,7 +267,7 @@ class Audio:
                 dtype=np.float32,
                 device=input_device_id,
                 blocksize=block_frame,
-                samplerate=AUDIO_SAMPLE_RATE,
+                samplerate=audio_sample_rate,
                 channels=input_max_channel,
                 extra_settings=input_extra_setting,
             )
@@ -253,7 +279,7 @@ class Audio:
                 dtype=np.float32,
                 device=output_device_id,
                 blocksize=block_frame,
-                samplerate=AUDIO_SAMPLE_RATE,
+                samplerate=audio_sample_rate,
                 channels=output_max_channel,
                 extra_settings=output_extra_setting,
             )
@@ -266,7 +292,7 @@ class Audio:
                 dtype=np.float32,
                 device=(input_device_id, output_device_id),
                 blocksize=block_frame,
-                samplerate=AUDIO_SAMPLE_RATE,
+                samplerate=audio_sample_rate,
                 channels=(input_max_channel, output_max_channel),
                 extra_settings=(input_extra_setting, output_extra_setting),
             )
@@ -281,7 +307,7 @@ class Audio:
                 dtype=np.float32,
                 device=output_monitor_id,
                 blocksize=block_frame,
-                samplerate=AUDIO_SAMPLE_RATE,
+                samplerate=audio_sample_rate,
                 channels=output_monitor_max_channel,
                 extra_settings=output_monitor_extra_setting,
             )
@@ -312,10 +338,12 @@ class Audio:
         output_device_id: int,
         output_monitor_id: int = None,
         exclusive_mode: bool = False,
-        asio_input_channel: int = -1,
-        asio_output_channel: int = -1,
-        asio_output_monitor_channel: int = -1,
+        asio_input_channel: int = 0,
+        asio_output_channel: int = 0,
+        asio_output_monitor_channel: int = 0,
         read_chunk_size: int = 192,
+        audio_sample_rate: int = AUDIO_SAMPLE_RATE,
+        asio_output_stereo: bool = True,
     ):
         self.stop()
 
@@ -353,14 +381,19 @@ class Audio:
                 exclusive=exclusive_mode, auto_convert=not exclusive_mode
             )
         elif (
-            input_audio_device
-            and "ASIO" in input_audio_device.host_api
+            output_audio_device
+            and "ASIO" in output_audio_device.host_api
             and asio_output_channel != -1
         ):
-            output_extra_setting = sd.AsioSettings(
-                channel_selectors=[asio_output_channel]
+            output_selectors = (
+                [asio_output_channel, asio_output_channel + 1]
+                if asio_output_stereo
+                else [asio_output_channel]
             )
-            output_channels = 1
+            output_extra_setting = sd.AsioSettings(
+                channel_selectors=output_selectors
+            )
+            output_channels = len(output_selectors)
 
         if self.use_monitor:
             output_monitor_device = self.get_output_audio_device(output_monitor_id)
@@ -381,7 +414,7 @@ class Audio:
                 )
                 monitor_channels = 1
 
-        block_frame = int((read_chunk_size * 128 / 48000) * AUDIO_SAMPLE_RATE)
+        block_frame = int((read_chunk_size * 128 / AUDIO_SAMPLE_RATE) * audio_sample_rate)
 
         try:
             self.run_audio_stream(
@@ -395,8 +428,10 @@ class Audio:
                 input_extra_setting,
                 output_extra_setting,
                 output_monitor_extra_setting,
+                audio_sample_rate,
             )
             self.running = True
         except Exception as error:
             print(f"An error occurred while streaming audio: {error}")
             print(traceback.format_exc())
+            raise

--- a/rvc/realtime/callbacks.py
+++ b/rvc/realtime/callbacks.py
@@ -1,12 +1,12 @@
 import os
 import sys
-import threading
 import numpy as np
 
 sys.path.append(os.getcwd())
 
 from rvc.realtime.audio import Audio
-from rvc.realtime.core import VoiceChanger
+from rvc.realtime.core import AUDIO_SAMPLE_RATE
+from rvc.realtime.worker import VoiceChangerWorker
 
 
 class AudioCallbacks:
@@ -48,30 +48,34 @@ class AudioCallbacks:
         # device: str = "cuda",
     ):
         self.pass_through = pass_through
-        self.lock = threading.Lock()
-        self.vc = VoiceChanger(
-            read_chunk_size,
-            cross_fade_overlap_size,
-            extra_convert_size,
-            model_path,
-            index_path,
-            f0_method,
-            embedder_model,
-            embedder_model_custom,
-            silent_threshold,
-            vad_enabled,
-            vad_sensitivity,
-            vad_frame_ms,
-            sid,
-            clean_audio,
-            clean_strength,
-            post_process,
-            record_audio,
-            record_audio_path,
-            export_format,
+        self._last_output = None
+        self._last_vol = 0
+
+        vc_kwargs = dict(
+            read_chunk_size=read_chunk_size,
+            cross_fade_overlap_size=cross_fade_overlap_size,
+            extra_convert_size=extra_convert_size,
+            model_path=model_path,
+            index_path=index_path,
+            f0_method=f0_method,
+            embedder_model=embedder_model,
+            embedder_model_custom=embedder_model_custom,
+            silent_threshold=silent_threshold,
+            vad_enabled=vad_enabled,
+            vad_sensitivity=vad_sensitivity,
+            vad_frame_ms=vad_frame_ms,
+            sid=sid,
+            clean_audio=clean_audio,
+            clean_strength=clean_strength,
+            post_process=post_process,
+            record_audio=record_audio,
+            record_audio_path=record_audio_path,
+            export_format=export_format,
             **kwargs,
-            # device,
         )
+        self.vc = VoiceChangerWorker(vc_kwargs)
+        self.vc.start()
+
         self.audio = Audio(
             self,
             f0_up_key,
@@ -100,29 +104,31 @@ class AudioCallbacks:
         proposed_pitch: bool = False,
         proposed_pitch_threshold: float = 155.0,
     ):
-        if self.pass_through:  # through
+        if self.pass_through:
             vol = float(np.sqrt(np.square(received_data).mean(dtype=np.float32)))
             return received_data, vol, [0, 0, 0], None
 
-        try:
-            with self.lock:
-                audio, vol, perf = self.vc.on_request(
-                    received_data,
-                    f0_up_key,
-                    index_rate,
-                    protect,
-                    volume_envelope,
-                    f0_autotune,
-                    f0_autotune_strength,
-                    proposed_pitch,
-                    proposed_pitch_threshold,
-                )
+        params = dict(
+            f0_up_key=f0_up_key,
+            index_rate=index_rate,
+            protect=protect,
+            volume_envelope=volume_envelope,
+            f0_autotune=f0_autotune,
+            f0_autotune_strength=f0_autotune_strength,
+            proposed_pitch=proposed_pitch,
+            proposed_pitch_threshold=proposed_pitch_threshold,
+        )
+        self.vc.submit(received_data, params)
 
-            return audio, vol, perf, None
-        except RuntimeError as error:
-            import traceback
+        result = self.vc.retrieve()
+        if result is not None:
+            audio, vol, perf_ms, _warmup = result
+            self._last_output = audio
+            self._last_vol = vol
+            return audio, vol, [0, perf_ms, 0], None
 
-            print(f"An error occurred during real-time voice conversion: {error}")
-            print(traceback.format_exc())
+        # No result ready yet; replay previous output to avoid underrun.
+        if self._last_output is not None and self._last_output.shape[0] == received_data.shape[0]:
+            return self._last_output, self._last_vol, [0, 0, 0], None
 
-            return np.zeros(1, dtype=np.float32), 0, [0, 0, 0], None
+        return np.zeros(received_data.shape[0], dtype=np.float32), 0, [0, 0, 0], None

--- a/rvc/realtime/callbacks.py
+++ b/rvc/realtime/callbacks.py
@@ -44,6 +44,7 @@ class AudioCallbacks:
         record_audio: bool = False,
         record_audio_path: str = None,
         export_format: str = "WAV",
+        audio_sample_rate: int = AUDIO_SAMPLE_RATE,
         **kwargs,
         # device: str = "cuda",
     ):
@@ -71,6 +72,7 @@ class AudioCallbacks:
             record_audio=record_audio,
             record_audio_path=record_audio_path,
             export_format=export_format,
+            audio_sample_rate=audio_sample_rate,
             **kwargs,
         )
         self.vc = VoiceChangerWorker(vc_kwargs)

--- a/rvc/realtime/callbacks.py
+++ b/rvc/realtime/callbacks.py
@@ -130,7 +130,10 @@ class AudioCallbacks:
             return audio, vol, [0, perf_ms, 0], None
 
         # No result ready yet; replay previous output to avoid underrun.
-        if self._last_output is not None and self._last_output.shape[0] == received_data.shape[0]:
+        if (
+            self._last_output is not None
+            and self._last_output.shape[0] == received_data.shape[0]
+        ):
             return self._last_output, self._last_vol, [0, 0, 0], None
 
         return np.zeros(received_data.shape[0], dtype=np.float32), 0, [0, 0, 0], None

--- a/rvc/realtime/core.py
+++ b/rvc/realtime/core.py
@@ -366,9 +366,7 @@ class Realtime:
         )
 
         # Scale output by the current input RMS to suppress residue during silence.
-        audio_out: torch.Tensor = self.resample_out(
-            audio_model * vol_t
-        )
+        audio_out: torch.Tensor = self.resample_out(audio_model * vol_t)
         return audio_out, vol, False
 
     def __del__(self):
@@ -531,11 +529,7 @@ class VoiceChanger:
             n_hops = block_size // hop
             if n_hops >= 1:
                 hop_energy = (
-                    audio[: n_hops * hop]
-                    .reshape(n_hops, hop)
-                    .abs()
-                    .max(dim=1)
-                    .values
+                    audio[: n_hops * hop].reshape(n_hops, hop).abs().max(dim=1).values
                 )
                 peak = hop_energy.max().item()
                 onset_sample = 0
@@ -562,7 +556,9 @@ class VoiceChanger:
         # Pad if audio is shorter than block_size + crossfade_frame.
         _need = block_size + self.crossfade_frame
         if audio.shape[0] < _need:
-            pad = torch.zeros(_need - audio.shape[0], device=audio.device, dtype=audio.dtype)
+            pad = torch.zeros(
+                _need - audio.shape[0], device=audio.device, dtype=audio.dtype
+            )
             audio = torch.cat([audio, pad])
         self.sola_buffer[:] = audio[block_size : block_size + self.crossfade_frame]
         audio_output = audio[:block_size].detach().cpu().numpy()

--- a/rvc/realtime/pipeline.py
+++ b/rvc/realtime/pipeline.py
@@ -255,7 +255,11 @@ class Realtime_Pipeline:
             if self.use_f0:
                 # Extract F0 from the most recent audio window only.
                 shift = (block_size_16k or skip_head * self.window) // self.window
-                f0_frame = block_size_16k + 800 if block_size_16k else skip_head * self.window + 800
+                f0_frame = (
+                    block_size_16k + 800
+                    if block_size_16k
+                    else skip_head * self.window + 800
+                )
                 if self.f0_method == "rmvpe":
                     f0_frame = 5120 * ((f0_frame - 1) // 5120 + 1) - 160
                 f0_frame = min(f0_frame, audio.shape[0])
@@ -272,15 +276,17 @@ class Realtime_Pipeline:
                 )
                 # Remove batch dimension.
                 f0_coarse_new = f0_coarse_new.squeeze(0)
-                f0_new        = f0_new.squeeze(0)
+                f0_new = f0_new.squeeze(0)
 
                 # Shift pitch cache left by one block and append new frames (trimmed [3:-1]).
                 pitch[:-shift] = pitch[shift:].clone()
                 pitchf[:-shift] = pitchf[shift:].clone()
-                interior_coarse = f0_coarse_new[3:-1] if f0_coarse_new.shape[0] > 4 else f0_coarse_new
-                interior_f      = f0_new[3:-1]        if f0_new.shape[0] > 4        else f0_new
-                pitch[-interior_coarse.shape[0]:]  = interior_coarse
-                pitchf[-interior_f.shape[0]:]      = interior_f
+                interior_coarse = (
+                    f0_coarse_new[3:-1] if f0_coarse_new.shape[0] > 4 else f0_coarse_new
+                )
+                interior_f = f0_new[3:-1] if f0_new.shape[0] > 4 else f0_new
+                pitch[-interior_coarse.shape[0] :] = interior_coarse
+                pitchf[-interior_f.shape[0] :] = interior_f
             else:
                 pitch, pitchf = None, None
 
@@ -316,8 +322,10 @@ class Realtime_Pipeline:
                 feats0 = F.interpolate(feats0.permute(0, 2, 1), scale_factor=2).permute(
                     0, 2, 1
                 )[:, :p_len, :]
-                pitch_p  = pitch[-p_len:].unsqueeze(0)
-                pitchf_p = pitchf[-p_len:].unsqueeze(0) * (formant_length / return_length)
+                pitch_p = pitch[-p_len:].unsqueeze(0)
+                pitchf_p = pitchf[-p_len:].unsqueeze(0) * (
+                    formant_length / return_length
+                )
 
                 # Pitch protection blending
                 if protect < 0.5:
@@ -342,7 +350,7 @@ class Realtime_Pipeline:
             ).float()
             # Match output RMS to the current block's input RMS.
             if volume_envelope < 1:
-                rms_src = audio[-(return_length * self.window):].cpu().numpy()
+                rms_src = audio[-(return_length * self.window) :].cpu().numpy()
                 out_audio = AudioProcessor.change_rms(
                     rms_src,
                     self.sample_rate,

--- a/rvc/realtime/worker.py
+++ b/rvc/realtime/worker.py
@@ -74,8 +74,10 @@ def _apply_config(vc, cfg):
             vc.crossfade_frame = cf
             vc.extra_frame = ef
             vc.vc_model.realloc(
-                vc.block_frame, vc.extra_frame,
-                vc.crossfade_frame, vc.sola_search_frame,
+                vc.block_frame,
+                vc.extra_frame,
+                vc.crossfade_frame,
+                vc.sola_search_frame,
             )
             vc.generate_strength()
 
@@ -89,6 +91,7 @@ def _apply_config(vc, cfg):
             vc.vc_model.vad = None
         elif vc.vc_model.vad is None:
             from rvc.realtime.utils.vad import VADProcessor
+
             vc.vc_model.vad = VADProcessor(
                 sensitivity_mode=cfg.get("vad_sensitivity", 3),
                 sample_rate=vc.vc_model.sample_rate,
@@ -103,6 +106,7 @@ def _apply_config(vc, cfg):
             strength = cfg.get("clean_strength", 0.5)
             if vc.vc_model.reduced_noise is None:
                 from noisereduce.torchgate import TorchGate
+
                 vc.vc_model.reduced_noise = TorchGate(
                     vc.vc_model.pipeline.tgt_sr,
                     prop_decrease=strength,
@@ -124,6 +128,7 @@ def _apply_config(vc, cfg):
     if model_path and vc.vc_model.model_path != model_path:
         import torch
         import torchaudio.transforms as tat
+
         vc.vc_model.model_path = model_path
         vc.vc_model.pipeline.vc.load_model(model_path)
         vc.vc_model.pipeline.vc.setup_network()
@@ -138,6 +143,7 @@ def _apply_config(vc, cfg):
     sid = cfg.get("sid")
     if sid is not None and vc.vc_model.pipeline.sid != sid:
         import torch
+
         vc.vc_model.pipeline.torch_sid = torch.tensor(
             [sid], device=vc.vc_model.pipeline.device, dtype=torch.int64
         )
@@ -147,9 +153,14 @@ def _apply_config(vc, cfg):
     if index_path is not None:
         if index_path and vc.vc_model.index_path != index_path:
             from rvc.realtime.pipeline import load_faiss_index
+
             index, big_npy = load_faiss_index(
-                index_path.strip().strip('"').strip("\n").strip('"')
-                .strip().replace("trained", "added")
+                index_path.strip()
+                .strip('"')
+                .strip("\n")
+                .strip('"')
+                .strip()
+                .replace("trained", "added")
             )
             vc.vc_model.pipeline.index = index
             vc.vc_model.pipeline.big_npy = big_npy
@@ -174,6 +185,7 @@ def _apply_config(vc, cfg):
         or vc.vc_model.embedder_model_custom != emb_custom
     ):
         from rvc.lib.utils import load_embedding
+
         old = vc.vc_model.pipeline.hubert_model
         del old
         hubert_model = load_embedding(emb, emb_custom)

--- a/rvc/realtime/worker.py
+++ b/rvc/realtime/worker.py
@@ -1,0 +1,265 @@
+import os
+import sys
+import multiprocessing as mp
+import numpy as np
+import time
+from queue import Empty, Full
+
+now_dir = os.getcwd()
+sys.path.append(now_dir)
+
+from rvc.realtime.core import AUDIO_SAMPLE_RATE
+
+
+def _worker_loop(vc_kwargs, input_q, output_q, config_q, stop_evt):
+    """Entry point for the voice conversion worker process."""
+    from rvc.realtime.core import VoiceChanger
+
+    vc = VoiceChanger(**vc_kwargs)
+
+    while not stop_evt.is_set():
+        # Apply pending config updates.
+        while True:
+            try:
+                cfg = config_q.get_nowait()
+            except Empty:
+                break
+            _apply_config(vc, cfg)
+
+        # Process one audio block.
+        try:
+            audio_in, params = input_q.get(timeout=0.05)
+        except Empty:
+            continue
+
+        start = time.perf_counter()
+        result, vol = vc.process_audio(audio_in, **params)
+        perf_ms = (time.perf_counter() - start) * 1000
+
+        warmup = vc.vc_model.warmup_blocks if vc.vc_model else 0
+
+        # Drop stale output to keep queue depth at most 1.
+        while True:
+            try:
+                output_q.get_nowait()
+            except Empty:
+                break
+        try:
+            output_q.put_nowait((result, vol, perf_ms, warmup))
+        except Full:
+            pass
+
+
+def _apply_config(vc, cfg):
+    """Apply a configuration update to the VoiceChanger in the worker process."""
+    if "record_start" in cfg:
+        vc.record_audio = True
+        vc.record_audio_path = cfg.get("record_audio_path")
+        vc.export_format = cfg.get("export_format", "WAV")
+        vc.setup_soundfile_record()
+        return
+
+    if "record_stop" in cfg:
+        vc.record_audio = False
+        vc.record_audio_path = None
+        vc.soundfile = None
+        return
+
+    # Realloc if crossfade/extra frame changed.
+    cf = cfg.get("crossfade_frame")
+    ef = cfg.get("extra_frame")
+    if cf is not None and ef is not None:
+        if vc.crossfade_frame != cf or vc.extra_frame != ef:
+            del vc.fade_in_window, vc.fade_out_window, vc.sola_buffer
+            vc.crossfade_frame = cf
+            vc.extra_frame = ef
+            vc.vc_model.realloc(
+                vc.block_frame, vc.extra_frame,
+                vc.crossfade_frame, vc.sola_search_frame,
+            )
+            vc.generate_strength()
+
+    # Silence threshold.
+    if "silent_threshold" in cfg:
+        vc.vc_model.input_sensitivity = 10 ** (cfg["silent_threshold"] / 20)
+
+    # VAD.
+    if "vad_enabled" in cfg:
+        if not cfg["vad_enabled"]:
+            vc.vc_model.vad = None
+        elif vc.vc_model.vad is None:
+            from rvc.realtime.utils.vad import VADProcessor
+            vc.vc_model.vad = VADProcessor(
+                sensitivity_mode=cfg.get("vad_sensitivity", 3),
+                sample_rate=vc.vc_model.sample_rate,
+                frame_duration_ms=cfg.get("vad_frame_ms", 30),
+            )
+
+    # Noise reduction.
+    if "clean_audio" in cfg:
+        if not cfg["clean_audio"]:
+            vc.vc_model.reduced_noise = None
+        else:
+            strength = cfg.get("clean_strength", 0.5)
+            if vc.vc_model.reduced_noise is None:
+                from noisereduce.torchgate import TorchGate
+                vc.vc_model.reduced_noise = TorchGate(
+                    vc.vc_model.pipeline.tgt_sr,
+                    prop_decrease=strength,
+                ).to(vc.vc_model.device)
+            vc.vc_model.reduced_noise.prop_decrease = strength
+
+    # Post-processing pedalboard.
+    if "post_process" in cfg:
+        kwargs = cfg.get("pedalboard_kwargs", {})
+        if not cfg["post_process"]:
+            vc.vc_model.board = None
+            vc.vc_model.kwargs = None
+        elif vc.vc_model.kwargs != kwargs:
+            vc.vc_model.board = vc.vc_model.setup_pedalboard(**kwargs)
+            vc.vc_model.kwargs = dict(kwargs)
+
+    # Model hot-swap.
+    model_path = cfg.get("model_path")
+    if model_path and vc.vc_model.model_path != model_path:
+        import torch
+        import torchaudio.transforms as tat
+        vc.vc_model.model_path = model_path
+        vc.vc_model.pipeline.vc.load_model(model_path)
+        vc.vc_model.pipeline.vc.setup_network()
+        vc.vc_model.pipeline.version = vc.vc_model.pipeline.vc.version
+        vc.vc_model.resample_out = tat.Resample(
+            orig_freq=vc.vc_model.pipeline.tgt_sr,
+            new_freq=AUDIO_SAMPLE_RATE,
+            dtype=torch.float32,
+        ).to(vc.vc_model.device)
+
+    # SID change.
+    sid = cfg.get("sid")
+    if sid is not None and vc.vc_model.pipeline.sid != sid:
+        import torch
+        vc.vc_model.pipeline.torch_sid = torch.tensor(
+            [sid], device=vc.vc_model.pipeline.device, dtype=torch.int64
+        )
+
+    # Index change.
+    index_path = cfg.get("index_path")
+    if index_path is not None:
+        if index_path and vc.vc_model.index_path != index_path:
+            from rvc.realtime.pipeline import load_faiss_index
+            index, big_npy = load_faiss_index(
+                index_path.strip().strip('"').strip("\n").strip('"')
+                .strip().replace("trained", "added")
+            )
+            vc.vc_model.pipeline.index = index
+            vc.vc_model.pipeline.big_npy = big_npy
+            vc.vc_model.index_path = index_path
+        elif not index_path:
+            vc.vc_model.pipeline.index = None
+            vc.vc_model.pipeline.big_npy = None
+            vc.vc_model.index_path = None
+
+    # F0 method change.
+    f0_method = cfg.get("f0_method")
+    if f0_method and vc.vc_model.pipeline.f0_method != f0_method:
+        f0_model = vc.vc_model.pipeline.setup_f0(f0_method)
+        vc.vc_model.pipeline.f0_model = f0_model
+        vc.vc_model.pipeline.f0_method = f0_method
+
+    # Embedder change.
+    emb = cfg.get("embedder_model")
+    emb_custom = cfg.get("embedder_model_custom")
+    if emb is not None and (
+        vc.vc_model.embedder_model != emb
+        or vc.vc_model.embedder_model_custom != emb_custom
+    ):
+        from rvc.lib.utils import load_embedding
+        old = vc.vc_model.pipeline.hubert_model
+        del old
+        hubert_model = load_embedding(emb, emb_custom)
+        hubert_model = hubert_model.to(vc.vc_model.device).float()
+        hubert_model.eval()
+        vc.vc_model.pipeline.hubert_model = hubert_model
+        vc.vc_model.embedder_model = emb
+        vc.vc_model.embedder_model_custom = emb_custom
+
+
+class _RealtimeState:
+    """Cached subset of Realtime state readable from the main process."""
+
+    def __init__(self):
+        self.warmup_blocks = 0
+
+
+class VoiceChangerWorker:
+    """Runs VoiceChanger in a separate process for non-blocking audio callbacks."""
+
+    def __init__(self, vc_kwargs):
+        ctx = mp.get_context("spawn")
+        self._input_q = ctx.Queue(maxsize=2)
+        self._output_q = ctx.Queue(maxsize=2)
+        self._config_q = ctx.Queue()
+        self._stop = ctx.Event()
+        self._vc_kwargs = vc_kwargs
+        self._process = None
+        # Cached state for main-process reads (change_callbacks_config / UI).
+        self.crossfade_frame = int(
+            vc_kwargs.get("cross_fade_overlap_size", 0.1) * AUDIO_SAMPLE_RATE
+        )
+        self.extra_frame = int(
+            vc_kwargs.get("extra_convert_size", 0.5) * AUDIO_SAMPLE_RATE
+        )
+        self.block_frame = vc_kwargs.get("read_chunk_size", 192) * 128
+        self.sola_search_frame = AUDIO_SAMPLE_RATE // 100
+        self.vc_model = _RealtimeState()
+
+    def start(self):
+        self._process = mp.get_context("spawn").Process(
+            target=_worker_loop,
+            args=(
+                self._vc_kwargs,
+                self._input_q,
+                self._output_q,
+                self._config_q,
+                self._stop,
+            ),
+            daemon=True,
+        )
+        self._process.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._process is not None:
+            self._process.join(timeout=5)
+            if self._process.is_alive():
+                self._process.kill()
+            self._process = None
+
+    def submit(self, audio_in, params):
+        """Submit an audio block and inference params (non-blocking, drops if full)."""
+        try:
+            self._input_q.put_nowait((audio_in, params))
+        except Full:
+            pass
+
+    def retrieve(self):
+        """Get the latest processed result (non-blocking).
+
+        Returns (audio, vol, perf_ms, warmup_blocks) or None.
+        """
+        result = None
+        while True:
+            try:
+                result = self._output_q.get_nowait()
+            except Empty:
+                break
+        if result is not None:
+            self.vc_model.warmup_blocks = result[3]
+        return result
+
+    def send_config(self, cfg):
+        """Send a configuration update dict to the worker process."""
+        try:
+            self._config_q.put_nowait(cfg)
+        except Full:
+            pass

--- a/tabs/realtime/realtime.py
+++ b/tabs/realtime/realtime.py
@@ -501,8 +501,6 @@ def start_realtime(
 
     yield "Starting Realtime...", interactive_false, interactive_visible
 
-    read_chunk_size = int(chunk_size * AUDIO_SAMPLE_RATE / 1000 / 128)
-
     sid = int(sid) if sid is not None else 0
 
     input_audio_gain /= 100.0
@@ -519,6 +517,8 @@ def start_realtime(
     except (ValueError, IndexError):
         yield "Incorrectly formatted audio device. Stopping.", interactive_true, interactive_false
         return
+
+    read_chunk_size = int(chunk_size * AUDIO_SAMPLE_RATE / 1000 / 128)
 
     callbacks_kwargs = {
         "pass_through": PASS_THROUGH,
@@ -595,23 +595,39 @@ def start_realtime(
     callbacks = AudioCallbacks(**callbacks_kwargs)
 
     audio_manager = callbacks.audio
-    audio_manager.start(
-        input_device_id=input_device_id,
-        output_device_id=output_device_id,
-        output_monitor_id=output_monitor_id,
-        exclusive_mode=exclusive_mode,
-        asio_input_channel=input_asio_channels,
-        asio_output_channel=output_asio_channels,
-        asio_output_monitor_channel=monitor_asio_channels,
-        read_chunk_size=read_chunk_size,
-    )
+    try:
+        audio_manager.start(
+            input_device_id=input_device_id,
+            output_device_id=output_device_id,
+            output_monitor_id=output_monitor_id,
+            exclusive_mode=exclusive_mode,
+            asio_input_channel=input_asio_channels,
+            asio_output_channel=output_asio_channels,
+            asio_output_monitor_channel=monitor_asio_channels,
+            read_chunk_size=read_chunk_size,
+        )
+    except Exception as error:
+        running = False
+        yield str(error), interactive_true, interactive_false
+        return
 
     yield "Realtime is ready!", interactive_false, interactive_visible
 
     while running and callbacks is not None and audio_manager is not None:
         time.sleep(0.1)
         if hasattr(audio_manager, "latency") and hasattr(audio_manager, "volume"):
-            yield f"Latency: {audio_manager.latency:.2f} ms | Volume: {audio_manager.volume:.2f} dB", interactive_false, interactive_true
+            warmup_remaining = (
+                callbacks.vc.vc_model.warmup_blocks
+                if callbacks is not None
+                and hasattr(callbacks, "vc")
+                and hasattr(callbacks.vc, "vc_model")
+                and hasattr(callbacks.vc.vc_model, "warmup_blocks")
+                else 0
+            )
+            if warmup_remaining > 0:
+                yield i18n("Warming up... ({} blocks remaining)").format(warmup_remaining), interactive_false, interactive_true
+            else:
+                yield f"Latency: {audio_manager.latency:.2f} ms | Volume: {audio_manager.volume:.2f} dB", interactive_false, interactive_true
 
     return gr.update(), gr.update(), gr.update()
 
@@ -631,79 +647,37 @@ def change_callbacks_config():
             callbacks_kwargs.get("extra_convert_size", 0.5) * AUDIO_SAMPLE_RATE
         )
 
+        cfg = {}
+
         if (
             callbacks.vc.crossfade_frame != crossfade_frame
             or callbacks.vc.extra_frame != extra_frame
         ):
-            # Deleting these things is not a good idea; they should only be overwritten directly.
-            # del (
-            #     callbacks.vc.vc_model.audio_buffer,
-            #     callbacks.vc.vc_model.convert_buffer,
-            #     callbacks.vc.vc_model.pitch_buffer,
-            #     callbacks.vc.vc_model.pitchf_buffer,
-            # )
-            del (
-                callbacks.vc.fade_in_window,
-                callbacks.vc.fade_out_window,
-                callbacks.vc.sola_buffer,
-            )
+            cfg["crossfade_frame"] = crossfade_frame
+            cfg["extra_frame"] = extra_frame
+            callbacks.vc.crossfade_frame = crossfade_frame
+            callbacks.vc.extra_frame = extra_frame
 
-            callbacks.vc.vc_model.realloc(
-                callbacks.vc.block_frame,
-                callbacks.vc.extra_frame,
-                callbacks.vc.crossfade_frame,
-                callbacks.vc.sola_search_frame,
-            )
-            callbacks.vc.generate_strength()
+        cfg["silent_threshold"] = callbacks_kwargs.get("silent_threshold", -90)
 
-        callbacks.vc.vc_model.input_sensitivity = 10 ** (
-            callbacks_kwargs.get("silent_threshold", -90) / 20
-        )
+        cfg["vad_enabled"] = callbacks_kwargs.get("vad_enabled", True)
+        cfg["vad_sensitivity"] = callbacks_kwargs.get("vad_sensitivity", 3)
+        cfg["vad_frame_ms"] = callbacks_kwargs.get("vad_frame_ms", 30)
 
-        vad_enabled = callbacks_kwargs.get("vad_enabled", True)
-        if vad_enabled is False:
-            callbacks.vc.vc_model.vad = None
-        elif vad_enabled and callbacks.vc.vc_model.vad is None:
-            from rvc.realtime.utils.vad import VADProcessor
+        cfg["clean_audio"] = callbacks_kwargs.get("clean_audio", False)
+        cfg["clean_strength"] = callbacks_kwargs.get("clean_strength", 0.5)
 
-            callbacks.vc.vc_model.vad = VADProcessor(
-                sensitivity_mode=3,
-                sample_rate=callbacks.vc.vc_model.sample_rate,
-                frame_duration_ms=30,
-            )
+        cfg["post_process"] = callbacks_kwargs.get("post_process", False)
+        cfg["pedalboard_kwargs"] = callbacks_kwargs.get("kwargs", {})
 
-        # The VAD parameters have been assigned by default.
-        # if callbacks.vc.vc_model.vad is not None:
-        #     callbacks.vc.vc_model.vad.vad.set_mode(vad_sensitivity)
-        #     callbacks.vc.vc_model.vad.frame_length = int(callbacks.vc.vc_model.sample_rate * (vad_frame_ms / 1000.0))
+        cfg["model_path"] = callbacks_kwargs.get("model_path", "")
+        cfg["sid"] = callbacks_kwargs.get("sid", 0)
+        cfg["index_path"] = callbacks_kwargs.get("index_path", "")
+        cfg["f0_method"] = callbacks_kwargs.get("f0_method", "")
+        cfg["embedder_model"] = callbacks_kwargs.get("embedder_model", "")
+        cfg["embedder_model_custom"] = callbacks_kwargs.get("embedder_model_custom", "")
 
-        clean_audio = callbacks_kwargs.get("clean_audio", False)
-        clean_strength = callbacks_kwargs.get("clean_strength", 0.5)
-
-        if clean_audio is False:
-            callbacks.vc.vc_model.reduced_noise = None
-        elif clean_audio and callbacks.vc.vc_model.reduced_noise is None:
-            from noisereduce.torchgate import TorchGate
-
-            callbacks.vc.vc_model.reduced_noise = TorchGate(
-                callbacks.vc.vc_model.pipeline.tgt_sr,
-                prop_decrease=clean_strength,
-            ).to(callbacks.vc.vc_model.device)
-
-        if callbacks.vc.vc_model.reduced_noise is not None:
-            callbacks.vc.vc_model.reduced_noise.prop_decrease = clean_strength
-
-        post_process = callbacks_kwargs.get("post_process", False)
-        kwargs = callbacks_kwargs.get("kwargs", {})
-
-        if post_process is False:
-            callbacks.vc.vc_model.board = None
-            callbacks.vc.vc_model.kwargs = None
-        elif post_process and callbacks.vc.vc_model.kwargs != kwargs:
-            # Post-process requires creating a new pendalboard.
-            new_board = callbacks.vc.vc_model.setup_pedalboard(**kwargs)
-            callbacks.vc.vc_model.board = new_board
-            callbacks.vc.vc_model.kwargs = kwargs.copy()
+        callbacks.vc.send_config(cfg)
 
         callbacks.audio.f0_up_key = callbacks_kwargs.get("f0_up_key", 0)
         callbacks.audio.index_rate = callbacks_kwargs.get("index_rate", 0.75)
@@ -727,79 +701,6 @@ def change_callbacks_config():
             "monitor_audio_gain", 1.0
         )
 
-        model_pth = callbacks_kwargs.get("model_path", callbacks.vc.vc_model.model_path)
-        if model_pth and callbacks.vc.vc_model.model_path != model_pth:
-            callbacks.vc.vc_model.model_path = model_pth
-            callbacks.vc.vc_model.pipeline.vc.load_model(model_pth)
-            callbacks.vc.vc_model.pipeline.vc.setup_network()
-            # Set a new version, otherwise it will crash.
-            callbacks.vc.vc_model.pipeline.version = (
-                callbacks.vc.vc_model.pipeline.vc.version
-            )
-
-        sid = callbacks_kwargs.get("sid", callbacks.vc.vc_model.pipeline.sid)
-        if callbacks.vc.vc_model.pipeline.sid != sid:
-            import torch
-
-            # This is for multi-SID models.
-            callbacks.vc.vc_model.pipeline.torch_sid = torch.tensor(
-                [sid], device=callbacks.vc.vc_model.pipeline.device, dtype=torch.int64
-            )
-
-        index_path = callbacks_kwargs.get("index_path", None)
-        if index_path:
-            if callbacks.vc.vc_model.index_path != index_path:
-                from rvc.realtime.pipeline import load_faiss_index
-
-                index, big_npy = load_faiss_index(
-                    index_path.strip()
-                    .strip('"')
-                    .strip("\n")
-                    .strip('"')
-                    .strip()
-                    .replace("trained", "added")
-                )
-
-                callbacks.vc.vc_model.pipeline.index = index
-                callbacks.vc.vc_model.pipeline.big_npy = big_npy
-                callbacks.vc.vc_model.index_path = index_path
-        else:
-            callbacks.vc.vc_model.pipeline.index = None
-            callbacks.vc.vc_model.pipeline.big_npy = None
-            callbacks.vc.vc_model.index_path = None
-
-        f0_method = callbacks_kwargs.get(
-            "f0_method", callbacks.vc.vc_model.pipeline.f0_method
-        )
-        if callbacks.vc.vc_model.pipeline.f0_method != f0_method:
-            f0_model = callbacks.vc.vc_model.pipeline.setup_f0(f0_method)
-            callbacks.vc.vc_model.pipeline.f0_model = f0_model
-            callbacks.vc.vc_model.pipeline.f0_method = f0_method
-
-        embedder_model = callbacks_kwargs.get(
-            "embedder_model", callbacks.vc.vc_model.embedder_model
-        )
-        embedder_model_custom = callbacks_kwargs.get(
-            "embedder_model_custom", callbacks.vc.vc_model.embedder_model_custom
-        )
-
-        if (
-            callbacks.vc.vc_model.embedder_model != embedder_model
-            or callbacks.vc.vc_model.embedder_model_custom != embedder_model_custom
-        ):
-            old_hubert_model = callbacks.vc.vc_model.pipeline.hubert_model
-            del old_hubert_model
-
-            from rvc.lib.utils import load_embedding
-
-            hubert_model = load_embedding(embedder_model, embedder_model_custom)
-            hubert_model = hubert_model.to(callbacks.vc.device).float()
-            hubert_model.eval()
-
-            callbacks.vc.vc_model.pipeline.hubert_model = hubert_model
-            callbacks.vc.vc_model.embedder_model = embedder_model
-            callbacks.vc.vc_model.embedder_model_custom = embedder_model_custom
-
 
 def change_config(value, key, if_kwargs=False):
     global callbacks_kwargs
@@ -817,6 +718,7 @@ def stop_realtime():
     global running, callbacks, audio_manager
     if running and audio_manager is not None and callbacks is not None:
         audio_manager.stop()
+        callbacks.vc.stop()
         running = False
         if hasattr(audio_manager, "latency"):
             del audio_manager.latency
@@ -925,18 +827,17 @@ def soundfile_record_audio(
                     now_dir, "assets", "audios", "record_audio.wav"
                 )
 
-            callbacks.vc.record_audio = True
-            callbacks.vc.record_audio_path = record_audio_path
-            callbacks.vc.export_format = export_format
-            callbacks.vc.setup_soundfile_record()
+            callbacks.vc.send_config({
+                "record_start": True,
+                "record_audio_path": record_audio_path,
+                "export_format": export_format,
+            })
 
             return "Stop", None
         else:
             gr.Info("Stop recording!")
 
-            callbacks.vc.record_audio = False
-            callbacks.vc.record_audio_path = None
-            callbacks.vc.soundfile = None
+            callbacks.vc.send_config({"record_stop": True})
 
             return "Start", record_audio_path
 
@@ -1163,6 +1064,7 @@ def realtime_tab():
                         value=True,
                         interactive=True,
                     )
+
 
             with gr.TabItem(i18n("Model Settings")):
                 with gr.Row():
@@ -1600,7 +1502,7 @@ def realtime_tab():
                     protect = gr.Slider(
                         minimum=0,
                         maximum=0.5,
-                        value=0.5,
+                        value=0.33,
                         label=i18n("Protect Voiceless Consonants"),
                         info=i18n(
                             "Safeguard distinct consonants and breathing sounds to prevent electro-acoustic tearing and other artifacts. Pulling the parameter to its maximum value of 0.5 offers comprehensive protection. However, reducing this value might decrease the extent of protection while potentially mitigating the indexing effect."
@@ -1665,7 +1567,7 @@ def realtime_tab():
                 chunk_size = gr.Slider(
                     minimum=2.7,
                     maximum=2730.7,
-                    value=768,
+                    value=250,
                     step=1,
                     label=i18n("Chunk Size (ms)"),
                     info=i18n(
@@ -1687,7 +1589,7 @@ def realtime_tab():
                 extra_convert_size = gr.Slider(
                     minimum=0.1,
                     maximum=5,
-                    value=0.5,
+                    value=2.5,
                     step=0.1,
                     label=i18n("Extra Conversion Size (s)"),
                     info=i18n(
@@ -1698,7 +1600,7 @@ def realtime_tab():
                 silent_threshold = gr.Slider(
                     minimum=-90,
                     maximum=-60,
-                    value=-90,
+                    value=-60,
                     step=1,
                     label=i18n("Silence Threshold (dB)"),
                     info=i18n(

--- a/tabs/realtime/realtime.py
+++ b/tabs/realtime/realtime.py
@@ -284,8 +284,13 @@ CONFIG_PATH = os.path.join(now_dir, "assets", "config.json")
 
 
 def save_realtime_settings(
-    input_device, output_device, monitor_device, model_file, index_file,
-    asio_enabled=None, audio_sample_rate=None,
+    input_device,
+    output_device,
+    monitor_device,
+    model_file,
+    index_file,
+    asio_enabled=None,
+    audio_sample_rate=None,
 ):
     """Save realtime settings to config.json"""
     try:
@@ -349,7 +354,9 @@ def load_realtime_settings():
                     "model_file": realtime_config.get("model_file", ""),
                     "index_file": realtime_config.get("index_file", ""),
                     "asio_enabled": realtime_config.get("asio_enabled", False),
-                    "audio_sample_rate": realtime_config.get("audio_sample_rate", 48000),
+                    "audio_sample_rate": realtime_config.get(
+                        "audio_sample_rate", 48000
+                    ),
                 }
     except Exception as e:
         print(f"Error loading realtime settings: {e}")
@@ -532,7 +539,9 @@ def start_realtime(
     _rt_cfg = load_realtime_settings()
     asio_enabled = _rt_cfg["asio_enabled"]
     audio_sample_rate = _rt_cfg["audio_sample_rate"]
-    audio_sample_rate = resolve_sample_rate(input_device_id, asio_enabled, audio_sample_rate)
+    audio_sample_rate = resolve_sample_rate(
+        input_device_id, asio_enabled, audio_sample_rate
+    )
     read_chunk_size = int(chunk_size * audio_sample_rate / 1000 / 128)
 
     callbacks_kwargs = {
@@ -643,7 +652,9 @@ def start_realtime(
                 else 0
             )
             if warmup_remaining > 0:
-                yield i18n("Warming up... ({} blocks remaining)").format(warmup_remaining), interactive_false, interactive_true
+                yield i18n("Warming up... ({} blocks remaining)").format(
+                    warmup_remaining
+                ), interactive_false, interactive_true
             else:
                 yield f"Latency: {audio_manager.latency:.2f} ms | Volume: {audio_manager.volume:.2f} dB", interactive_false, interactive_true
 
@@ -845,11 +856,13 @@ def soundfile_record_audio(
                     now_dir, "assets", "audios", "record_audio.wav"
                 )
 
-            callbacks.vc.send_config({
-                "record_start": True,
-                "record_audio_path": record_audio_path,
-                "export_format": export_format,
-            })
+            callbacks.vc.send_config(
+                {
+                    "record_start": True,
+                    "record_audio_path": record_audio_path,
+                    "export_format": export_format,
+                }
+            )
 
             return "Stop", None
         else:
@@ -1079,7 +1092,6 @@ def realtime_tab():
                         value=True,
                         interactive=True,
                     )
-
 
             with gr.TabItem(i18n("Model Settings")):
                 with gr.Row():

--- a/tabs/realtime/realtime.py
+++ b/tabs/realtime/realtime.py
@@ -12,7 +12,7 @@ now_dir = os.getcwd()
 sys.path.append(now_dir)
 
 from rvc.realtime.callbacks import AudioCallbacks
-from rvc.realtime.audio import list_audio_device
+from rvc.realtime.audio import list_audio_device, resolve_sample_rate
 from rvc.realtime.core import AUDIO_SAMPLE_RATE
 
 from assets.i18n.i18n import I18nAuto
@@ -284,7 +284,8 @@ CONFIG_PATH = os.path.join(now_dir, "assets", "config.json")
 
 
 def save_realtime_settings(
-    input_device, output_device, monitor_device, model_file, index_file
+    input_device, output_device, monitor_device, model_file, index_file,
+    asio_enabled=None, audio_sample_rate=None,
 ):
     """Save realtime settings to config.json"""
     try:
@@ -314,6 +315,10 @@ def save_realtime_settings(
             config["realtime"]["model_file"] = model_file or ""
         if monitor_device is not None:
             config["realtime"]["index_file"] = index_file or ""
+        if asio_enabled is not None:
+            config["realtime"]["asio_enabled"] = asio_enabled
+        if audio_sample_rate is not None:
+            config["realtime"]["audio_sample_rate"] = audio_sample_rate
 
         with open(CONFIG_PATH, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=2, ensure_ascii=False)
@@ -343,6 +348,8 @@ def load_realtime_settings():
                     ),
                     "model_file": realtime_config.get("model_file", ""),
                     "index_file": realtime_config.get("index_file", ""),
+                    "asio_enabled": realtime_config.get("asio_enabled", False),
+                    "audio_sample_rate": realtime_config.get("audio_sample_rate", 48000),
                 }
     except Exception as e:
         print(f"Error loading realtime settings: {e}")
@@ -356,6 +363,8 @@ def load_realtime_settings():
         "client_monitor_device": "",
         "model_file": "",
         "index_file": "",
+        "asio_enabled": False,
+        "audio_sample_rate": AUDIO_SAMPLE_RATE,
     }
 
 
@@ -408,6 +417,7 @@ def start_realtime(
     output_audio_device: str,
     output_audio_gain: int,
     output_asio_channels: int,
+    asio_output_stereo: bool,
     monitor_output_device: str,
     monitor_audio_gain: int,
     monitor_asio_channels: int,
@@ -518,7 +528,12 @@ def start_realtime(
         yield "Incorrectly formatted audio device. Stopping.", interactive_true, interactive_false
         return
 
-    read_chunk_size = int(chunk_size * AUDIO_SAMPLE_RATE / 1000 / 128)
+    # Load ASIO and sample rate settings from config.
+    _rt_cfg = load_realtime_settings()
+    asio_enabled = _rt_cfg["asio_enabled"]
+    audio_sample_rate = _rt_cfg["audio_sample_rate"]
+    audio_sample_rate = resolve_sample_rate(input_device_id, asio_enabled, audio_sample_rate)
+    read_chunk_size = int(chunk_size * audio_sample_rate / 1000 / 128)
 
     callbacks_kwargs = {
         "pass_through": PASS_THROUGH,
@@ -553,6 +568,7 @@ def start_realtime(
         "record_audio": record_audio,
         "record_audio_path": record_audio_path,
         "export_format": export_format,
+        "audio_sample_rate": audio_sample_rate,
         "kwargs": {
             "reverb": reverb,
             "pitch_shift": pitch_shift,
@@ -601,10 +617,12 @@ def start_realtime(
             output_device_id=output_device_id,
             output_monitor_id=output_monitor_id,
             exclusive_mode=exclusive_mode,
-            asio_input_channel=input_asio_channels,
-            asio_output_channel=output_asio_channels,
-            asio_output_monitor_channel=monitor_asio_channels,
+            asio_input_channel=input_asio_channels if asio_enabled else -1,
+            asio_output_channel=output_asio_channels if asio_enabled else -1,
+            asio_output_monitor_channel=monitor_asio_channels if asio_enabled else -1,
             read_chunk_size=read_chunk_size,
+            audio_sample_rate=audio_sample_rate,
+            asio_output_stereo=asio_output_stereo,
         )
     except Exception as error:
         running = False
@@ -922,16 +940,13 @@ def realtime_tab():
                                 interactive=True,
                             )
                             input_asio_channels = gr.Slider(
-                                minimum=-1,
+                                minimum=0,
                                 maximum=16,
-                                value=-1,
+                                value=0,
                                 step=1,
                                 label=i18n("Input ASIO Channel"),
-                                info=i18n(
-                                    "For ASIO drivers, selects a specific input channel. Leave at -1 for default."
-                                ),
                                 interactive=True,
-                                visible=not client_mode,
+                                visible=saved_settings["asio_enabled"],
                             )
                     with gr.Accordion("Output Device", open=True):
                         with gr.Column():
@@ -964,16 +979,19 @@ def realtime_tab():
                                 interactive=True,
                             )
                             output_asio_channels = gr.Slider(
-                                minimum=-1,
+                                minimum=0,
                                 maximum=16,
-                                value=-1,
+                                value=0,
                                 step=1,
                                 label=i18n("Output ASIO Channel"),
-                                info=i18n(
-                                    "For ASIO drivers, selects a specific output channel. Leave at -1 for default."
-                                ),
                                 interactive=True,
-                                visible=not client_mode,
+                                visible=saved_settings["asio_enabled"],
+                            )
+                            asio_output_stereo = gr.Checkbox(
+                                label=i18n("Stereo"),
+                                value=True,
+                                interactive=True,
+                                visible=saved_settings["asio_enabled"],
                             )
                 with gr.Accordion(i18n("Monitor Device (Optional)"), open=False):
                     with gr.Column():
@@ -1011,16 +1029,13 @@ def realtime_tab():
                             interactive=True,
                         )
                         monitor_asio_channels = gr.Slider(
-                            minimum=-1,
+                            minimum=0,
                             maximum=16,
-                            value=-1,
+                            value=0,
                             step=1,
                             label=i18n("Monitor ASIO Channel"),
-                            info=i18n(
-                                "For ASIO drivers, selects a specific monitor output channel. Leave at -1 for default."
-                            ),
                             interactive=True,
-                            visible=not client_mode,
+                            visible=saved_settings["asio_enabled"],
                         )
                 with gr.Accordion(i18n("Record Audio (Optional)"), open=False):
                     with gr.Column():
@@ -1941,6 +1956,7 @@ def realtime_tab():
                     output_audio_device,
                     output_audio_gain,
                     output_asio_channels,
+                    asio_output_stereo,
                     monitor_output_device,
                     monitor_audio_gain,
                     monitor_asio_channels,

--- a/tabs/settings/sections/realtime_audio.py
+++ b/tabs/settings/sections/realtime_audio.py
@@ -62,9 +62,7 @@ def realtime_audio_tab():
         with gr.Column():
             asio_enabled = gr.Checkbox(
                 label=i18n("Enable ASIO"),
-                info=i18n(
-                    "Enable ASIO driver support. (Requires restarting Applio)"
-                ),
+                info=i18n("Enable ASIO driver support. (Requires restarting Applio)"),
                 value=saved_asio,
                 interactive=True,
                 visible=IS_WINDOWS,

--- a/tabs/settings/sections/realtime_audio.py
+++ b/tabs/settings/sections/realtime_audio.py
@@ -1,0 +1,97 @@
+import os
+import sys
+import json
+import gradio as gr
+
+now_dir = os.getcwd()
+sys.path.append(now_dir)
+
+from assets.i18n.i18n import I18nAuto
+from rvc.realtime.core import AUDIO_SAMPLE_RATE
+
+i18n = I18nAuto()
+
+CONFIG_PATH = os.path.join(now_dir, "assets", "config.json")
+IS_WINDOWS = sys.platform == "win32"
+
+
+def _load():
+    try:
+        if os.path.exists(CONFIG_PATH):
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            rt = cfg.get("realtime", {})
+            return (
+                rt.get("asio_enabled", False),
+                rt.get("audio_sample_rate", AUDIO_SAMPLE_RATE),
+            )
+    except Exception as e:
+        print(f"Error loading realtime audio settings: {e}")
+    return False, AUDIO_SAMPLE_RATE
+
+
+def _save_asio_enabled(value):
+    try:
+        cfg = {}
+        if os.path.exists(CONFIG_PATH):
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+        cfg.setdefault("realtime", {})["asio_enabled"] = value
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        print(f"Error saving asio_enabled: {e}")
+
+
+def _save_audio_sample_rate(value):
+    try:
+        cfg = {}
+        if os.path.exists(CONFIG_PATH):
+            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+        cfg.setdefault("realtime", {})["audio_sample_rate"] = value
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+    except Exception as e:
+        print(f"Error saving audio_sample_rate: {e}")
+
+
+def realtime_audio_tab():
+    saved_asio, saved_sr = _load()
+    with gr.Row():
+        with gr.Column():
+            asio_enabled = gr.Checkbox(
+                label=i18n("Enable ASIO"),
+                info=i18n(
+                    "Enable ASIO driver support. (Requires restarting Applio)"
+                ),
+                value=saved_asio,
+                interactive=True,
+                visible=IS_WINDOWS,
+            )
+            audio_sample_rate = gr.Dropdown(
+                label=i18n("Sample Rate"),
+                info=i18n(
+                    "Sample rate used for audio streaming. Specify the actual sample rate configured on your device, as drivers may report incorrect values."
+                ),
+                choices=[44100, 48000, 88200, 96000, 176400, 192000],
+                value=saved_sr,
+                interactive=True,
+                visible=saved_asio and IS_WINDOWS,
+            )
+            if IS_WINDOWS:
+                asio_enabled.change(
+                    fn=_save_asio_enabled,
+                    inputs=[asio_enabled],
+                    outputs=[],
+                )
+                asio_enabled.change(
+                    fn=lambda v: gr.update(visible=v),
+                    inputs=[asio_enabled],
+                    outputs=[audio_sample_rate],
+                )
+                audio_sample_rate.change(
+                    fn=_save_audio_sample_rate,
+                    inputs=[audio_sample_rate],
+                    outputs=[],
+                )

--- a/tabs/settings/settings.py
+++ b/tabs/settings/settings.py
@@ -10,6 +10,7 @@ from assets.i18n.i18n import I18nAuto
 i18n = I18nAuto()
 
 from tabs.settings.sections.presence import presence_tab
+from tabs.settings.sections.realtime_audio import realtime_audio_tab
 from tabs.settings.sections.themes import theme_tab
 from tabs.settings.sections.version import version_tab
 from tabs.settings.sections.lang import lang_tab
@@ -33,6 +34,7 @@ def settings_tab(filter_state_trigger=None):
             show_progress=False,
         )
         presence_tab()
+        realtime_audio_tab()
         theme_tab()
         version_tab()
         lang_tab()


### PR DESCRIPTION
## Description

Add ASIO driver support for realtime voice conversion on Windows, along with the multiprocessing infrastructure required to support it.

### Multiprocessing worker (prerequisite for ASIO)
- Move voice conversion to a separate process via `VoiceChangerWorker`, using a submit/retrieve pattern with multiprocessing queues for non-blocking audio processing
- Replace synchronous `on_request()` in callbacks with async submit + retrieve with underrun replay fallback
- Add `_apply_config()` for hot-swapping model, index, F0, and other parameters via IPC
- Refactor realtime UI to use `send_config()` IPC instead of direct `vc_model` manipulation

### Inference quality improvements
- Replace full-buffer F0 extraction with a sliding window approach that only processes the newest audio block
- Add warmup phase that fills the convert buffer before enabling model output, preventing initial pops/clicks
- Add onset-aware sin² fade-in for silence-to-speech transitions
- Scale model output by input RMS to suppress residual noise during silence

### ASIO driver support
- Add `resolve_sample_rate()` for ASIO vs non-ASIO rate selection with PortAudio re-initialization
- Support stereo ASIO output channel selection
- Add settings UI with ASIO enable checkbox and sample rate dropdown (44100–192000 Hz), persisted to `config.json`
- Load `realtime.asio_enabled` from config at startup and set `SD_ENABLE_ASIO` environment variable
- Suppress Windows `ConnectionResetError` during asyncio shutdown (WinError 10054)

### Other
- Simplify `check_the_device()` to use channel count instead of opening a test stream
- Add i18n keys for warmup status and ASIO settings UI across all 60 language files

## Motivation and Context

ASIO drivers on Windows require dedicated host API initialization and explicit sample rate handling that conflicts with the existing synchronous, single-process audio pipeline. Specifically, PortAudio must be re-initialized to switch between ASIO and default host APIs, and ASIO's strict timing requirements make blocking voice conversion calls in the audio callback thread untenable.

To support ASIO reliably, voice conversion was moved to a separate process (`VoiceChangerWorker`) with queue-based IPC, decoupling the audio callback from model inference latency. This multiprocessing architecture also enabled the warmup phase and onset detection improvements, as the worker can now fill its convert buffer asynchronously before the audio stream begins producing output.


## How has this been tested?

- Manual testing with realtime voice conversion on Windows with NVIDIA GPU
- Tested with both default (WDM/WASAPI) and ASIO audio drivers
- Verified warmup phase outputs silence for the expected number of blocks before enabling conversion
- Verified ASIO sample rate dropdown correctly persists to config.json and applies on restart
- Confirmed multiprocessing worker handles config hot-swap (model, index, F0 method) without audio interruption


## Screenshots (if appropriate):

N/A


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
