### PR TITLE
Allow run-applio.sh pass extra argv, eventually to gradio launch(...)

### DIFF
--- a/run-applio.sh
+++ b/run-applio.sh
@@ -6,4 +6,5 @@ printf "\033]0;Applio\007"
  export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
  
 clear
-python app.py --open
+python app.py --open "$@"
+


### PR DESCRIPTION
## Description

Added a "$@" to pass all argv to gradio, so you can pass `--share` or `--server-name` and so.

## Motivation and Context
Was trying to run a local machine at home (a strong one), to not go public and depend on gradio and colab
The sh script didn't pass the arguments into the `gradio.launch(...)` function, now it does :)

## How has this been tested?
Ran locally and tested that the arguments affected the run (`--share`, `--server-name`)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ?] My change requires a change to the documentation.
- [ NO] I have updated the documentation accordingly.
- [ NO] I have added tests to cover my changes.
- [ CI?] All new and existing tests passed.
