### PR TITLE
Optimize realtime conversion hot-path allocations and SOLA processing

### DIFF
--- a/rvc/realtime/core.py
+++ b/rvc/realtime/core.py
@@ -451,6 +451,9 @@ class VoiceChanger:
         )
 
         self.fade_out_window: torch.Tensor = 1 - self.fade_in_window
+        self.sola_denominator_kernel = torch.ones(
+            1, 1, self.crossfade_frame, device=self.device, dtype=torch.float32
+        )
         # The size will change from the previous result, so the record will be deleted.
         self.sola_buffer = torch.zeros(
             self.crossfade_frame, device=self.device, dtype=torch.float32
@@ -513,10 +516,7 @@ class VoiceChanger:
         ].float()
         cor_nom = F.conv1d(conv_input, self.sola_buffer[None, None, :])
         cor_den = torch.sqrt(
-            F.conv1d(
-                conv_input**2,
-                torch.ones(1, 1, self.crossfade_frame, device=self.device),
-            )
+            F.conv1d(conv_input**2, self.sola_denominator_kernel)
             + 1e-8
         )
         sola_offset = torch.argmax(cor_nom[0, 0] / cor_den[0, 0])
@@ -543,12 +543,9 @@ class VoiceChanger:
             # Apply sin² fade-in over crossfade_frame duration from onset.
             fade_len = min(block_size - onset_sample, self.crossfade_frame)
             if fade_len > 0:
-                t = torch.linspace(
-                    0.0, 1.0, steps=fade_len, device=self.device, dtype=torch.float32
-                )
-                audio[onset_sample : onset_sample + fade_len] *= (
-                    torch.sin(0.5 * np.pi * t) ** 2
-                )
+                audio[onset_sample : onset_sample + fade_len] *= self.fade_in_window[
+                    :fade_len
+                ]
         else:
             audio[: self.crossfade_frame] *= self.fade_in_window
             audio[: self.crossfade_frame] += self.sola_buffer * self.fade_out_window

--- a/rvc/realtime/pipeline.py
+++ b/rvc/realtime/pipeline.py
@@ -122,6 +122,9 @@ class Realtime_Pipeline:
         self.resamplers = {}
         self.f0_model = self.setup_f0(self.f0_method)
         self.dtype = vc.dtype
+        # Reuse scalar tensors to avoid per-block allocations.
+        self._rate_tensor = torch.zeros(1, device=self.device, dtype=torch.float32)
+        self._p_len_tensor = torch.zeros(1, device=self.device, dtype=torch.int64)
 
     def setup_f0(self, f0_method: str = "fcpe"):
         if f0_method == "rmvpe":
@@ -279,8 +282,9 @@ class Realtime_Pipeline:
                 f0_new = f0_new.squeeze(0)
 
                 # Shift pitch cache left by one block and append new frames (trimmed [3:-1]).
-                pitch[:-shift] = pitch[shift:].clone()
-                pitchf[:-shift] = pitchf[shift:].clone()
+                if shift > 0:
+                    pitch[:-shift] = pitch[shift:].clone()
+                    pitchf[:-shift] = pitchf[shift:].clone()
                 interior_coarse = (
                     f0_coarse_new[3:-1] if f0_coarse_new.shape[0] > 4 else f0_coarse_new
                 )
@@ -341,12 +345,15 @@ class Realtime_Pipeline:
 
             pitchf_p = pitchf_p.to(self.dtype) if self.use_f0 else None
             # Trim oldest context so model output covers only the current block.
-            rate = torch.tensor(
-                [return_length / p_len], device=self.device, dtype=torch.float32
-            )
-            p_len = torch.tensor([p_len], device=self.device, dtype=torch.int64)
+            self._rate_tensor.fill_(return_length / p_len)
+            self._p_len_tensor.fill_(p_len)
             out_audio = self.vc.inference(
-                feats, p_len, self.torch_sid, pitch_p, pitchf_p, rate
+                feats,
+                self._p_len_tensor,
+                self.torch_sid,
+                pitch_p,
+                pitchf_p,
+                self._rate_tensor,
             ).float()
             # Match output RMS to the current block's input RMS.
             if volume_envelope < 1:


### PR DESCRIPTION
### Motivation
- Reduce per-block Python/Torch allocations and memory churn in the realtime voice conversion hot path to improve latency and throughput.
- Avoid unnecessary slice/copy work and repeated tensor construction in SOLA/onset processing to make the realtime pipeline more efficient while preserving audio behavior.

### Description
- Reuse scalar tensors by adding `self._rate_tensor` and `self._p_len_tensor` in `Realtime_Pipeline` to avoid allocating `rate`/`p_len` on every block and fill them with `fill_()` before calling `vc.inference`.
- Guard pitch cache shifts with `if shift > 0:` to skip redundant slice/copy when `shift == 0` in `Realtime_Pipeline.voice_conversion`.
- Precompute and cache the SOLA denominator convolution kernel as `self.sola_denominator_kernel` in `VoiceChanger` and replace per-call `torch.ones(...)` with the cached tensor to reduce allocations.
- Reuse the existing `self.fade_in_window` for onset fade-in instead of creating a new `torch.linspace`/`sin` envelope per block in `VoiceChanger.process_audio`.

### Testing
- Ran syntax/bytecode check with `python -m py_compile rvc/realtime/pipeline.py rvc/realtime/core.py` and it completed without errors.
- No additional automated runtime tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5924ed988332aae875e49b25d6ff)