### PR TITLE
Optimize realtime pipeline: reduce allocations and stabilize FAISS retrieval

### DIFF
--- a/rvc/realtime/core.py
+++ b/rvc/realtime/core.py
@@ -106,6 +106,9 @@ class Realtime:
             new_freq=AUDIO_SAMPLE_RATE,
             dtype=torch.float32,
         ).to(self.device)
+        # Cached kernels/windows to avoid per-block allocations in SOLA path.
+        self.sola_den_kernel = None
+        self.onset_fade_window = None
 
     def setup_pedalboard(self, **kwargs):
         board = Pedalboard()
@@ -455,6 +458,10 @@ class VoiceChanger:
         self.sola_buffer = torch.zeros(
             self.crossfade_frame, device=self.device, dtype=torch.float32
         )
+        self.sola_den_kernel = torch.ones(
+            1, 1, self.crossfade_frame, device=self.device, dtype=torch.float32
+        )
+        self.onset_fade_window = self.fade_in_window
 
     def setup_soundfile_record(self):
         import soundfile as sf
@@ -515,7 +522,7 @@ class VoiceChanger:
         cor_den = torch.sqrt(
             F.conv1d(
                 conv_input**2,
-                torch.ones(1, 1, self.crossfade_frame, device=self.device),
+                self.sola_den_kernel,
             )
             + 1e-8
         )
@@ -543,12 +550,9 @@ class VoiceChanger:
             # Apply sin² fade-in over crossfade_frame duration from onset.
             fade_len = min(block_size - onset_sample, self.crossfade_frame)
             if fade_len > 0:
-                t = torch.linspace(
-                    0.0, 1.0, steps=fade_len, device=self.device, dtype=torch.float32
-                )
-                audio[onset_sample : onset_sample + fade_len] *= (
-                    torch.sin(0.5 * np.pi * t) ** 2
-                )
+                audio[onset_sample : onset_sample + fade_len] *= self.onset_fade_window[
+                    :fade_len
+                ]
         else:
             audio[: self.crossfade_frame] *= self.fade_in_window
             audio[: self.crossfade_frame] += self.sola_buffer * self.fade_out_window

--- a/rvc/realtime/pipeline.py
+++ b/rvc/realtime/pipeline.py
@@ -299,8 +299,9 @@ class Realtime_Pipeline:
             )
 
             feats = torch.cat((feats, feats[:, -1:, :]), 1)
-            # make a copy for pitch guidance and protection
-            feats0 = feats.detach().clone() if self.use_f0 else None
+            # Only allocate a protection branch when blending is enabled.
+            use_protection_blend = self.use_f0 and protect < 0.5
+            feats0 = feats.detach().clone() if use_protection_blend else None
 
             try:
                 if (
@@ -328,7 +329,7 @@ class Realtime_Pipeline:
                 )
 
                 # Pitch protection blending
-                if protect < 0.5:
+                if use_protection_blend:
                     pitchff = pitchf_p.detach().clone()
                     pitchff[pitchf_p > 0] = 1
                     pitchff[pitchf_p < 1] = protect
@@ -391,8 +392,10 @@ class Realtime_Pipeline:
         if self.dtype == torch.float16:
             npy = npy.astype(np.float32)
         score, ix = index.search(npy, k=8)
-        weight = np.square(1 / score)
-        weight /= weight.sum(axis=1, keepdims=True)
+        # Stabilize inverse-distance weighting to avoid inf/nan when score ~= 0.
+        safe_score = np.maximum(score, 1e-6)
+        weight = np.square(1.0 / safe_score)
+        weight /= np.maximum(weight.sum(axis=1, keepdims=True), 1e-6)
         npy = np.sum(big_npy[ix] * np.expand_dims(weight, axis=2), axis=1)
         if self.dtype == torch.float16:
             npy = npy.astype(np.float16)


### PR DESCRIPTION
### Motivation

- Reduce per-block allocation overhead in the realtime SOLA path to improve callback latency and realtime responsiveness.
- Avoid unnecessary tensor cloning during feature processing to speed up the common inference path.
- Prevent unstable behavior (Inf/NaN) when FAISS returns near-zero distances during speaker-retrieval blending.

### Description

- Cache SOLA-related tensors in `Realtime/VoiceChanger` by adding `self.sola_den_kernel` and `self.onset_fade_window` and reuse them in the SOLA convolution and onset fade logic to avoid per-block allocations (`rvc/realtime/core.py`).
- Only create the pitch-protection copy `feats0` when protection blending is actually enabled by checking `use_protection_blend = self.use_f0 and protect < 0.5`, avoiding needless clones in the common path (`rvc/realtime/pipeline.py`).
- Stabilize inverse-distance weighting used for FAISS-based speaker embedding retrieval by clamping scores with an `epsilon` and normalizing with a safe denominator to avoid `inf`/`nan` (`rvc/realtime/pipeline.py`).

### Testing

- Compiled the modified modules with `python -m compileall rvc/realtime/core.py rvc/realtime/pipeline.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5924ed988332aae875e49b25d6ff)