### PR TITLE
fixed docker run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 # Run the app
 ENTRYPOINT ["python3"]
-CMD ["app.py"]
+CMD ["app.py", "--server-name", "0.0.0.0", "--port", "6969"]


### PR DESCRIPTION
## Description

Fix Docker external access for the Gradio UI by binding the application to `0.0.0.0` inside the container.

Updated Docker `CMD` to pass:

```dockerfile
--server-name 0.0.0.0
```

This allows Docker port mapping to work correctly when exposing the application outside the container.

## Motivation and Context

Currently the container starts successfully, but the UI is inaccessible from the host machine even when using proper Docker port forwarding.

Example:

```bash
docker run -p 19794:6969 applio
```

The application responds correctly inside the container:

```bash
curl http://127.0.0.1:6969
```

but cannot be opened externally.

Root cause:
`app.py` defaults to:

```python
DEFAULT_SERVER_NAME = "127.0.0.1"
```

which binds Gradio only to the container loopback interface.

This PR fixes external accessibility without modifying the application source code behavior for local environments.

## How has this been tested?

Tested with Docker Desktop on Windows.

Build:

```bash
docker build -t applio .
```

Run:

```bash
docker run -p 19794:6969 applio
```

Verified that:

* the container starts successfully
* Gradio launches correctly
* the UI becomes accessible from the host machine at:

```text
http://localhost:19794
```

## Screenshots (if appropriate):

N/A

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
