### PR TITLE
Fix release breakage caused by #1243

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - main
       - master
     paths:
-      - 'assets/config.json'
+      - 'assets/config_template.json'
       - '.github/workflows/release.yml'
 
 jobs:


### PR DESCRIPTION
#1243 was not aware that `config.json` was used by `release.yml`, so this fixes that (hopefully)

## Description

Changed the `config.json` path in the release workflow YAML to `config_template.json`

## Motivation and Context

The release workflow could not run with the old `config.json` path in use. Hopefully it will now.

I do feel like this is a poor fix, since a template file should not be directly used in computing, but I don't see another way. Maybe if I was more familiar with the config file's exact purpose and usage...

## How has this been tested?

I was completely unable to test this.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
