### PR TITLE
Changed Filelist.txt absolute to relative pathing 

### DIFF
--- a/rvc/train/extract/preparing_files.py
+++ b/rvc/train/extract/preparing_files.py
@@ -51,17 +51,22 @@ def generate_filelist(model_path: str, sample_rate: int, include_mutes: int = 2)
         sid = name.split("_")[0]
         if sid not in sids:
             sids.append(sid)
-        options.append(
-            f"{os.path.join(gt_wavs_dir, name)}.wav|{os.path.join(feature_dir, name)}.npy|{os.path.join(f0_dir, name)}.wav.npy|{os.path.join(f0nsf_dir, name)}.wav.npy|{sid}"
-        )
+
+        # Calculate relative pathing 
+        rel_wav = os.path.relpath(f"{os.path.join(gt_wavs_dir, name)}.wav")
+        rel_feat = os.path.relpath(f"{os.path.join(feature_dir, name)}.npy")
+        rel_f0 = os.path.relpath(f"{os.path.join(f0_dir, name)}.wav.npy")
+        rel_f0nsf = os.path.relpath(f"{os.path.join(f0nsf_dir, name)}.wav.npy")
+        
+        options.append(f"{rel_wav}|{rel_feat}|{rel_f0}|{rel_f0nsf}|{sid}")
 
     if include_mutes > 0:
-        mute_audio_path = os.path.join(
+        mute_audio_path = os.path.relpath(os.path.join(
             mute_base_path, "sliced_audios", f"mute{sample_rate}.wav"
-        )
-        mute_feature_path = os.path.join(mute_base_path, f"extracted", "mute.npy")
-        mute_f0_path = os.path.join(mute_base_path, "f0", "mute.wav.npy")
-        mute_f0nsf_path = os.path.join(mute_base_path, "f0_voiced", "mute.wav.npy")
+        ))
+        mute_feature_path = os.path.relpath(os.path.join(mute_base_path, f"extracted", "mute.npy"))
+        mute_f0_path = os.path.relpath(os.path.join(mute_base_path, "f0", "mute.wav.npy"))
+        mute_f0nsf_path = os.path.relpath(os.path.join(mute_base_path, "f0_voiced", "mute.wav.npy"))
 
         # adding x files per sid
         for sid in sids * include_mutes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When extracting features and generating filelist.txt, instead of Absolute pathing, use relative pathing pointing at the logs directory

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When moving models from one machine to another to continue training, moving Applio or whatever the case may be I have to manually replace its absolute pathing, making training models more portable at the same time as shortening filelist.txt length

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Trained a test model from scratch using relative pathing with no issues

## Screenshots (if appropriate):

<img width="1416" height="368" alt="image" src="https://github.com/user-attachments/assets/54bb796f-6822-4211-9911-9836bc7477ff" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
