### PR TITLE
docs: fix libportaudio2 install blocker + add T4/GPU notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,18 @@ verification on an actual NVIDIA Tesla T4 (16GB, sm_75/Turing).
   ```
   RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.cuda.HalfTensor) should be the same
   ```
-- There is no bf16 code path in the repo either (0 matches for bf16 handling),
-  so bf16-capable GPUs (e.g. this T4, `is_bf16_supported()=True`) gain nothing
-  and also hit no bf16-specific bugs — the only currently working precision
-  is fp32.
+- The *inference* pipeline has no bf16 code path either — it's all fp32 as
+  described above. (Training is a separate story: `tabs/settings/sections/precision.py`,
+  `rvc/train/train.py`, and `rvc/train/anyprecision_optimizer.py` do have real
+  bf16 support gated on `torch.cuda.is_bf16_supported()`, but that's unrelated
+  to the inference path this note covers.) So for inference specifically,
+  bf16-capable GPUs (e.g. this T4, `is_bf16_supported()=True`) gain nothing
+  and also hit no bf16-specific bugs — the only currently working inference
+  precision is fp32.
 - Net effect for T4/Turing and similar GPUs: no fp16/bf16 tensor-core
-  acceleration is available through this codebase today; treat fp32 as the
-  only supported precision until the hardcoded casts are refactored (tracked
+  acceleration is available through the *inference* codepath today; treat
+  fp32 as the only supported inference precision until the hardcoded casts
+  are refactored (tracked
   as a code-logic issue, out of scope for this doc-only note).
 
 ## Positive findings on T4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+Notes for AI coding agents (and humans automating Applio) based on hands-on
+verification on an actual NVIDIA Tesla T4 (16GB, sm_75/Turing).
+
+## Headless / CLI usage
+
+- `core.py infer` is the CLI entry point (also used by the official
+  [No-UI Colab notebook](https://colab.research.google.com/github/iahispano/applio/blob/main/assets/Applio_NoUI.ipynb)).
+  It works fully headlessly with no code changes and is the reliable path if
+  the Gradio GUI (`run-applio.sh` / `python app.py`) fails to start in your
+  environment (see the PortAudio note in the README).
+- `core.py infer` does **not** expose `--device`, `--dtype`, `--fp16`,
+  `--half`, or `--precision` flags — none of these exist in `infer_parser`.
+  GPU selection is automatic (`torch.cuda.is_available()`); there is no
+  silent CPU fallback and no way to force CPU/GPU or a dtype via the CLI.
+
+## Precision (fp16/bf16) — fp32 only, by design of the current code
+
+- The inference pipeline (HuBERT embedder, `net_g` / HiFi-GAN vocoder, RMVPE,
+  FCPE) is hardcoded to fp32 via explicit `.float()` calls, e.g.
+  `rvc/infer/infer.py:72` and `:479`, and `rvc/infer/pipeline.py:326` and
+  `:367`.
+- This is not merely "fp16 unsupported" — it actively breaks if you try to
+  force it. Casting an already-loaded model to fp16 externally (e.g.
+  `vc.hubert_model.half()`, no repo code changes) still crashes, because
+  `pipeline.py` casts the input tensor back to fp32 right before the model
+  call. The crash reproduces deterministically at HuBERT's first conv1d
+  layer:
+  ```
+  RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.cuda.HalfTensor) should be the same
+  ```
+- There is no bf16 code path in the repo either (0 matches for bf16 handling),
+  so bf16-capable GPUs (e.g. this T4, `is_bf16_supported()=True`) gain nothing
+  and also hit no bf16-specific bugs — the only currently working precision
+  is fp32.
+- Net effect for T4/Turing and similar GPUs: no fp16/bf16 tensor-core
+  acceleration is available through this codebase today; treat fp32 as the
+  only supported precision until the hardcoded casts are refactored (tracked
+  as a code-logic issue, out of scope for this doc-only note).
+
+## Positive findings on T4
+
+- `torch` is version- and index-pinned in `requirements.txt`
+  (`torch==2.7.1+cu128` via `--extra-index-url .../whl/cu128`), so a fresh
+  install matches the CUDA wheel's minimum driver requirement instead of
+  silently requiring a newer driver than what's installed.
+- GPU is auto-selected with no silent CPU fallback.
+- HuBERT's attention implementation defaults to `sdpa` (no forced
+  `flash_attention_2`), which runs correctly on T4 (sm_75).
+- Model footprint is small (<200MB) and peak VRAM during inference measured
+  at ~1.1GB on a 16GB T4 — no OOM risk in practice.
+- int8 quantization (bitsandbytes), CUDA Graphs, and `torch.compile` are not
+  wired into the inference path (0 matches in the repo); given the small
+  model size the expected benefit is limited anyway.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This launches the Gradio interface in your default browser.
 If the GUI doesn't come up in your environment, Applio can also run fully headless via the CLI, e.g.:
 
 ```
-python core.py infer --pitch 0 --index_rate 0.75 --volume_envelope 1 --protect 0.5 --hop_length 128 --f0_method rmvpe --input_path input.wav --output_path output.wav --pth_path logs/<model>/model.pth --index_path logs/<model>/model.index --split_audio False --f0_autotune False --clean_audio False --clean_strength 0.5 --export_format WAV --embedder_model contentvec --sid 0
+python core.py infer --pitch 0 --index_rate 0.75 --volume_envelope 1 --protect 0.5 --f0_method rmvpe --input_path input.wav --output_path output.wav --pth_path logs/<model>/model.pth --index_path logs/<model>/model.index --split_audio False --f0_autotune False --clean_audio False --clean_strength 0.5 --export_format WAV --embedder_model contentvec --sid 0
 ```
 
 This is the same entry point used by the official [No-UI Colab notebook](https://colab.research.google.com/github/iahispano/applio/blob/main/assets/Applio_NoUI.ipynb) and requires no GUI/browser.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ Run the installation script based on your operating system:
 - **Windows:** Double-click `run-install.bat`.
 - **Linux/macOS:** Execute `run-install.sh`.
 
+> [!NOTE]
+> On Linux, the realtime voice conversion tab imports the `sounddevice` Python package unconditionally at startup, which requires the system-level PortAudio shared library. If it is not already present, `run-applio.sh` (`python app.py`) will fail to start entirely — even if you never intend to use the realtime tab — with:
+> ```
+> OSError: PortAudio library not found
+> ```
+> Install it before running Applio, e.g. on Debian/Ubuntu:
+> ```
+> sudo apt-get install -y libportaudio2
+> ```
+> (or the equivalent package for your distribution).
+
 ### 2. Running Applio
 
 Start Applio using:
@@ -72,6 +83,14 @@ Start Applio using:
 - **Linux/macOS:** Run `run-applio.sh`.
 
 This launches the Gradio interface in your default browser.
+
+If the GUI doesn't come up in your environment, Applio can also run fully headless via the CLI, e.g.:
+
+```
+python core.py infer --pitch 0 --index_rate 0.75 --volume_envelope 1 --protect 0.5 --hop_length 128 --f0_method rmvpe --input_path input.wav --output_path output.wav --pth_path logs/<model>/model.pth --index_path logs/<model>/model.index --split_audio False --f0_autotune False --clean_audio False --clean_strength 0.5 --export_format WAV --embedder_model contentvec --sid 0
+```
+
+This is the same entry point used by the official [No-UI Colab notebook](https://colab.research.google.com/github/iahispano/applio/blob/main/assets/Applio_NoUI.ipynb) and requires no GUI/browser.
 
 ### 3. Optional: TensorBoard Monitoring
 


### PR DESCRIPTION
## Description

Doc-only changes, verified on an actual NVIDIA Tesla T4 (16GB, sm_75):

1. **README**: documents a system-level dependency that currently blocks the app from starting at all on a fresh Debian/Ubuntu install.
2. **README**: adds a headless CLI example (`core.py infer`) as a documented fallback if the GUI doesn't start.
3. **New `AGENTS.md`**: documents CLI flag surface, current fp32-only precision behavior, and positive T4-specific findings, to save future contributors/agents from re-discovering these by trial and error.

No code changes.

## Motivation and Context

On a fresh Ubuntu 22.04 box, running the README's documented quickstart (`run-applio.sh` → `python app.py`) crashes immediately at import time:

```
Traceback (most recent call last):
  File "app.py", line 71, in <module>
    from tabs.realtime.realtime import realtime_tab
  File "tabs/realtime/realtime.py", line 2, in <module>
    import sounddevice as sd
  File ".venv/lib/python3.12/site-packages/sounddevice.py", line 72, in <module>
    raise OSError('PortAudio library not found')
OSError: PortAudio library not found
```

`tabs/realtime/realtime.py` unconditionally imports `sounddevice` at module load, and `app.py` unconditionally imports `tabs.realtime.realtime` — so the realtime tab's dependency blocks every tab (inference, training, etc.) even for users who never touch realtime conversion. `sounddevice` is only the Python binding; the actual PortAudio shared library (`libportaudio2` on Debian/Ubuntu) is a separate system package that isn't mentioned anywhere in the README or `requirements.txt`. I checked existing GitHub issues and didn't find this reported before.

The fix is a one-line install (`sudo apt-get install -y libportaudio2`), confirmed to bring the Gradio UI up (HTTP 200) within 10 seconds. This PR documents that fix rather than changing the import behavior in code (which would be a logic change and is out of scope here — noted as a possible follow-up).

Separately, while testing GPU acceleration options on the T4, I found:
- `core.py infer` has no `--device`/`--fp16`/`--dtype` flags at all (confirmed via `infer_parser` in `core.py`) — an agent or user naturally trying `--device cuda --fp16 True` gets `unrecognized arguments`.
- The inference pipeline is not just "fp16 unsupported" but fp32-hardcoded in a way that actively crashes if fp16 is forced externally (casting the loaded HuBERT/`net_g` modules to `.half()` without touching repo code): `pipeline.py` re-casts inputs to fp32 right before the model call, producing a dtype-mismatch `RuntimeError` at HuBERT's first conv1d layer. This is worth documenting explicitly so nobody burns time chasing a "hidden" fp16 flag.
- On the positive side: `torch==2.7.1+cu128` is version+index pinned in `requirements.txt`, so a fresh install matched the T4's driver without any CUDA/driver mismatch; GPU is auto-selected with no silent CPU fallback; HuBERT's attention backend defaults to `sdpa` (no forced `flash_attention_2`), which works fine on T4 (sm_75).

These are recorded in a new `AGENTS.md` so future contributors/agents don't have to rediscover them by trial and error.

## How has this been tested?

Manually verified on a real Tesla T4 16GB GPU (Azure ML, Ubuntu 22.04, driver 550.163.01, Python 3.12.13, `torch==2.7.1+cu128`, `transformers==5.4.0`, `gradio==5.50.0`):

- Fresh env via README's `run-install.sh` steps verbatim → succeeded, `cuda_available=True`, `Tesla T4` detected.
- `python app.py` (GUI) → reproduced the `OSError: PortAudio library not found` crash verbatim.
- `sudo apt-get install -y libportaudio2` → GUI then started and served HTTP 200 within 10s.
- `python core.py infer ...` (CLI, same invocation as the official No-UI Colab notebook, paths substituted for local) → succeeded with no fixes needed, produced an audibly/measurably converted output (RMS changed, resampled to 48kHz), 26.19s including model load.
- `core.py infer --device cuda --fp16 True` → confirmed `unrecognized arguments` error.
- Casting the loaded HuBERT/`net_g` modules to `.half()` (no repo code changes) and re-running inference → reproduced the exact dtype-mismatch `RuntimeError` at HuBERT's first conv1d layer.
- 3x repeated fp32 inference run → consistent ~1.1GB peak VRAM (well within the T4's 16GB).

This PR only changes documentation (`README.md`, new `AGENTS.md`); no application code was modified, so no application-level regression testing applies.

## Screenshots (if appropriate):

N/A (documentation-only change).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (doc-only change, not applicable)
- [ ] All new and existing tests passed. (no code changed)
