### PR TITLE
Need portaudio install for fedora.

### DIFF
--- a/run-install.sh
+++ b/run-install.sh
@@ -66,6 +66,13 @@ install_ffmpeg() {
     fi
 }
 
+install_deps() {
+    if command -v dnf > /dev/null; then
+        log_message "Installing deps needed using dnf..."
+        sudo dnf install -y portaudio --allowerasing 
+    fi
+}
+
 # Function to install FFmpeg using Flatpak
 install_ffmpeg_flatpak() {
     if command -v flatpak > /dev/null; then
@@ -114,6 +121,7 @@ prepare_install() {
 # Function to create the virtual environment and install dependencies
 create_venv() {
     install_build_tools
+    install_deps
 
     if ! command -v uv --version >/dev/null 2>&1; then
         log_message "Installing uv"


### PR DESCRIPTION
When installing with the script for Fedora, portaudio dep is missing.

## Description

Add a new function named install_deps for others distros or components if needed.
In this function, install deps needed for the software
Call this function when installing

## Motivation and Context

Instead of install for me the missing component, it's better to install it automatically

## How has this been tested?

On my machine :)

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
