### PR TITLE
Add ffmpeg fallback for audio formats libsndfile cannot decode (M4A/AAC)

### DIFF
--- a/rvc/lib/utils.py
+++ b/rvc/lib/utils.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import shutil
+import subprocess
 import soxr
 import librosa
 import soundfile as sf
@@ -44,10 +46,28 @@ def load_audio_16k(file):
     return audio.flatten()
 
 
+def read_audio_any(file, sample_rate):
+    # libsndfile cannot decode AAC/M4A; fall back to ffmpeg for those formats
+    try:
+        return sf.read(file)
+    except sf.LibsndfileError:
+        ffmpeg = shutil.which("ffmpeg")
+        if not ffmpeg:
+            raise
+        result = subprocess.run(
+            [ffmpeg, "-v", "error", "-i", file, "-f", "f32le",
+             "-acodec", "pcm_f32le", "-ac", "1", "-ar", str(sample_rate), "-"],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.decode(errors="ignore"))
+        return np.frombuffer(result.stdout, dtype=np.float32), sample_rate
+
+
 def load_audio(file, sample_rate):
     try:
         file = file.strip(" ").strip('"').strip("\n").strip('"').strip(" ")
-        audio, sr = sf.read(file)
+        audio, sr = read_audio_any(file, sample_rate)
         if len(audio.shape) > 1:
             audio = librosa.to_mono(audio.T)
         if sr != sample_rate:
@@ -70,7 +90,7 @@ def load_audio_infer(
         file = file.strip(" ").strip('"').strip("\n").strip('"').strip(" ")
         if not os.path.isfile(file):
             raise FileNotFoundError(f"File not found: {file}")
-        audio, sr = sf.read(file)
+        audio, sr = read_audio_any(file, sample_rate)
         if len(audio.shape) > 1:
             audio = librosa.to_mono(audio.T)
         if sr != sample_rate:


### PR DESCRIPTION
## Problem

Uploading an M4A/AAC file to inference fails with:

```
RuntimeError: An error occurred loading the audio: Error opening 'assets/audios/recording.m4a': Format not recognised.
```

M4A is the default output of the Windows Sound Recorder and of WhatsApp voice notes, so this is a common first experience for new users: they record something, upload it, and conversion fails with a generic error.

Root cause: `load_audio` / `load_audio_infer` read files with soundfile (libsndfile), which does not decode AAC.

## Fix

Add a small `read_audio_any` helper in `rvc/lib/utils.py`: try `sf.read` first and, if libsndfile cannot open the file, decode it with ffmpeg (mono float32 at the requested sample rate, piped via stdout, no temp files).

- No behavior change for formats libsndfile already handles (wav, flac, mp3, ogg): `sf.read` still handles those.
- No new Python dependency; uses the ffmpeg binary from PATH.
- If ffmpeg is not available, the original `LibsndfileError` is re-raised, so systems without ffmpeg see the same error as today.
- Decoding at the requested sample rate also skips the extra librosa resample step in that path.

## Testing

Tested on Windows 11 (RTX 3060, CUDA build) by running `core.py infer` with an M4A recording from the Windows Sound Recorder: fails with 'Format not recognised' before the patch, converts normally after it. Also verified that WAV inference still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)