### PR TITLE
Wire the batch formant toggle to its own checkbox

### DIFF
--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -1923,7 +1923,7 @@ def inference_tab():
     )
     formant_shifting_batch.change(
         fn=toggle_visible_formant_shifting,
-        inputs=[formant_shifting],
+        inputs=[formant_shifting_batch],
         outputs=[
             formant_row_batch,
             formant_preset_batch,


### PR DESCRIPTION
The batch formant options don't follow their own checkbox. Their visibility is driven by the single tab's checkbox instead, which means checking the batch toggle does nothing unless the single tab's checkbox is also checked.

The handler registration passes `formant_shifting` where it should pass `formant_shifting_batch`:

```diff
 formant_shifting_batch.change(
     fn=toggle_visible_formant_shifting,
-    inputs=[formant_shifting],
+    inputs=[formant_shifting_batch],
```

Found while making the inference tabs usable with VoiceOver. The two tabs look identical, so this is easy to miss visually. With a screen reader it is more easily noticeable, because the changed toggle does nothing to the page you are on.
