### PR TITLE
Announce job start and completion with toasts for screen reader users

### DIFF
--- a/tabs/download/download.py
+++ b/tabs/download/download.py
@@ -183,6 +183,16 @@ def download_handler(is_custom, model, sample_rate, url_g, url_d):
 
 
 def download_tab():
+    def _download_with_toast(*args):
+        gr.Info(i18n("Downloading model..."))
+        result = run_download_script(*args)
+        if isinstance(result, str):
+            if "error" in result.lower() or "failed" in result.lower():
+                gr.Warning(result)
+            else:
+                gr.Info(result)
+        return result
+
     with gr.Column():
         gr.Markdown(value=i18n("## Download Model"))
         model_link = gr.Textbox(
@@ -199,7 +209,7 @@ def download_tab():
         )
         model_download_button = gr.Button(i18n("Download Model"))
         model_download_button.click(
-            fn=run_download_script,
+            fn=_download_with_toast,
             inputs=[model_link],
             outputs=[model_download_output_info],
         )

--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -1169,9 +1169,17 @@ def inference_tab():
                 gr.Info(message)
                 return message, None
             try:
-                return run_infer_script(*args)
+                gr.Info(i18n("Converting audio..."))
+                result = run_infer_script(*args)
+                gr.Info(result[0])
+                return result
             except Exception:
                 traceback.print_exc()
+                gr.Warning(
+                    i18n(
+                        "An error occurred during audio conversion. Please check the console logs for more details."
+                    )
+                )
                 return (
                     "An error occurred during audio conversion. Please check the console logs for more details.",
                     None,

--- a/tabs/train/train.py
+++ b/tabs/train/train.py
@@ -310,6 +310,26 @@ def auto_enable_checkpointing():
 
 # Train Tab
 def train_tab():
+    def _preprocess_with_toast(*args):
+        gr.Info(i18n("Preprocessing dataset..."))
+        result = run_preprocess_script(*args)
+        if isinstance(result, str):
+            if "error" in result.lower() or "failed" in result.lower():
+                gr.Warning(result)
+            else:
+                gr.Info(result)
+        return result
+
+    def _extract_with_toast(*args):
+        gr.Info(i18n("Extracting features..."))
+        result = run_extract_script(*args)
+        if isinstance(result, str):
+            if "error" in result.lower() or "failed" in result.lower():
+                gr.Warning(result)
+            else:
+                gr.Info(result)
+        return result
+
     # Model settings section
     with gr.Accordion(i18n("Model Settings")):
         with gr.Row():
@@ -500,7 +520,7 @@ def train_tab():
         with gr.Row():
             preprocess_button = gr.Button(i18n("Preprocess Dataset"))
             preprocess_button.click(
-                fn=run_preprocess_script,
+                fn=_preprocess_with_toast,
                 inputs=[
                     model_name,
                     dataset_path,
@@ -595,7 +615,7 @@ def train_tab():
         )
         extract_button = gr.Button(i18n("Extract Features"))
         extract_button.click(
-            fn=run_extract_script,
+            fn=_extract_with_toast,
             inputs=[
                 model_name,
                 f0_method,
@@ -757,6 +777,7 @@ def train_tab():
                 message = "You must agree to the Terms of Use to proceed."
                 gr.Info(message)
                 return message
+            gr.Info(i18n("Training started..."))
             return run_train_script(*args)
 
         terms_checkbox = gr.Checkbox(

--- a/tabs/tts/tts.py
+++ b/tabs/tts/tts.py
@@ -359,9 +359,17 @@ def tts_tab():
             gr.Info(message)
             return message, None
         try:
-            return run_tts_script(*args)
+            gr.Info(i18n("Starting text-to-speech..."))
+            result = run_tts_script(*args)
+            gr.Info(result[0])
+            return result
         except Exception:
             traceback.print_exc()
+            gr.Warning(
+                i18n(
+                    "An error occurred during TTS conversion. Please check the console logs for more details."
+                )
+            )
             return (
                 "An error occurred during TTS conversion. Please check the console logs for more details.",
                 None,


### PR DESCRIPTION
A blind user running Applio gets no signal when a job starts or finishes. Conversions, TTS, preprocessing, extraction and model link downloads all end in silence, and the result textboxes are not read aloud, leaving the user with no clue of what is happening, if it worked, or if it failed.

Gradio toasts are announced by screen readers (they render with role=status and aria-live). Applio already uses them for the pretrained model download and the prerequisites check. This change extends that to the other long-running jobs:

- single conversion and TTS: toast on start, toast with the result message on completion, warning toast on error
- preprocessing, feature extraction and model link downloads: wrapped so they announce start, the returned result, and errors (a returned message mentioning "error" or "failed" is shown as a warning)
- training: announces its start. A run can last hours, so completion feedback needs its own approach and is left out here

Start messages are translated like the rest of the UI. Error toasts reuse the exact strings these functions already return, which means we only need eight new translation strings.

Batch conversion and the real-time engine are left out for now; they need progress reporting rather than single toasts.

Tested on macOS with VoiceOver: start and completion of a conversion, a TTS run, preprocessing, extraction and a model download are all spoken. The calls are plain gradio toasts and behave the same on every platform. This came out of an accessibility pass on the macOS port. The same class of problem has come up in gradio itself (gradio-app/gradio#12855, fixed in #13542), reported by a blind screen-reader user; Applio came up in that thread as another app built on it.
