### PR TITLE
Announce batch conversion progress with toasts

### DIFF
--- a/rvc/infer/infer.py
+++ b/rvc/infer/infer.py
@@ -37,6 +37,17 @@ logging.getLogger("faiss").setLevel(logging.WARNING)
 logging.getLogger("faiss.loader").setLevel(logging.WARNING)
 
 
+def _toast(message, warning=False):
+    """Shows a toast notification in the Gradio UI, falling back to stdout
+    when Gradio is unavailable (e.g. when the engine runs headless)."""
+    try:
+        import gradio as gr
+
+        (gr.Warning if warning else gr.Info)(message)
+    except Exception:
+        print(message)
+
+
 class VoiceConverter:
     """
     A class for performing voice conversion using the Retrieval-Based Voice Conversion (RVC) method.
@@ -388,20 +399,46 @@ class VoiceConverter:
                 )
             ]
             print(f"Detected {len(audio_files)} audio files for inference.")
+            total = len(audio_files)
+            converted = skipped = 0
+            _next_milestone = 25
+            _toast(f"Batch conversion started: {total} files")
             for a in audio_files:
                 new_input = os.path.join(audio_input_paths, a)
                 new_output = os.path.splitext(a)[0] + "_output.wav"
                 new_output = os.path.join(audio_output_path, new_output)
                 if os.path.exists(new_output):
-                    continue
-                self.convert_audio(
-                    audio_input_path=new_input,
-                    audio_output_path=new_output,
-                    **kwargs,
-                )
+                    skipped += 1
+                else:
+                    self.convert_audio(
+                        audio_input_path=new_input,
+                        audio_output_path=new_output,
+                        **kwargs,
+                    )
+                    converted += 1
+                processed = converted + skipped
+                # Milestone toast: fires at the first file past each threshold
+                # (the label carries the threshold). processed < total
+                # suppresses the 100% milestone (it would double-announce with
+                # the terminal toast); total >= 8 keeps small batches
+                # toast-free between start and terminal.
+                if (
+                    total >= 8
+                    and processed < total
+                    and processed * 100 // total >= _next_milestone
+                ):
+                    _toast(f"{processed}/{total} files converted ({_next_milestone}%)")
+                    _next_milestone += 25
             print(f"Conversion completed at '{audio_input_paths}'.")
             elapsed_time = time.time() - start_time
             print(f"Batch conversion completed in {elapsed_time:.2f} seconds.")
+            _toast(
+                f"Batch conversion completed: {converted} converted, "
+                f"{skipped} skipped in {elapsed_time:.0f}s"
+            )
+        except Exception as e:
+            _toast(f"Batch conversion failed: {e}", warning=True)
+            raise
         finally:
             os.remove(os.path.join(now_dir, "assets", "infer_pid.txt"))
 


### PR DESCRIPTION
PR #1271 covered single conversions and the training stages. Batch conversion was initially left out. However, a large folder can run for a long time with no feedback for blind or disabled users.

The tab layer only sees the start and end of the call. The new announcements come from inside the conversion loop. Here are the toasts we now show with this PR:

- a toast when the batch starts, with the file count
- at 25%, 50% and 75%, a progress toast; example: "12/48 files converted (25%)"
- on completion, a toast with the converted and skipped counts and the elapsed time
- on failure, a warning toast with the error

Batches under 8 files skip the milestone toasts and only get start and completion. The new progress toasts are only needed on long jobs. Skipped files count toward the progress; the percentages track how far through the folder the run is. The helper imports gradio lazily and falls back to a plain print when no interface is running, meaning the module still works headless. Messages are short, and include useful numbers; they stay in english because the conversion engine doesn't use the translation setup, and I'd rather not couple it to the UI's locale files for the sake of four words.

Tested successfully on macOS with Voiceover across batches of different sizes.