### PR TITLE
Accessibility improvements: add toasts to the remaining long-running jobs

### DIFF
--- a/tabs/extra/sections/processing.py
+++ b/tabs/extra/sections/processing.py
@@ -12,6 +12,11 @@ i18n = I18nAuto()
 
 
 def processing_tab():
+    def _model_info_with_toast(pth_path):
+        result = run_model_information_script(pth_path)
+        gr.Info(i18n("Model information loaded."))
+        return result
+
     model_view_model_path = gr.Textbox(
         label=i18n("Path to Model"),
         info=i18n("Introduce the model pth path"),
@@ -28,7 +33,7 @@ def processing_tab():
     )
     model_view_button = gr.Button(i18n("View"))
     model_view_button.click(
-        fn=run_model_information_script,
+        fn=_model_info_with_toast,
         inputs=[model_view_model_path],
         outputs=[model_view_output_info],
     )

--- a/tabs/plugins/plugins.py
+++ b/tabs/plugins/plugins.py
@@ -14,6 +14,20 @@ plugins_core.check_new_folders()
 
 
 def plugins_tab():
+    def _plugin_install_with_toast(dropbox):
+        gr.Info(i18n("Installing plugin..."))
+        try:
+            return plugins_core.save_plugin_dropbox(dropbox)
+        except gr.Error:
+            raise  # gradio announces gr.Error natively
+        except Exception:
+            gr.Warning(
+                i18n(
+                    "An error occurred installing the plugin. Please check the console logs for more details."
+                )
+            )
+            raise
+
     with gr.TabItem(i18n("Plugin Installer")):
         dropbox = gr.File(
             label=i18n("Drag your plugin.zip to install it"),
@@ -21,7 +35,7 @@ def plugins_tab():
         )
 
         dropbox.upload(
-            fn=plugins_core.save_plugin_dropbox,
+            fn=_plugin_install_with_toast,
             inputs=[dropbox],
             outputs=[dropbox],
         )

--- a/tabs/realtime/realtime.py
+++ b/tabs/realtime/realtime.py
@@ -1685,6 +1685,37 @@ def realtime_tab():
                 return
             yield from start_realtime(*args)
 
+        def _realtime_with_toast(terms_accepted, *args):
+            if terms_accepted:
+                gr.Info(i18n("Starting real-time conversion..."))
+            # start_realtime reports failures as yielded status strings
+            # ("Error: ...", "Please select valid input/output devices!",
+            # "Model path not provided. Aborting conversion.") instead of
+            # raising, so scan every yielded update for failure markers.
+            failures = (
+                "error",
+                "failed",
+                "stopping",
+                "aborting",
+                "please select",
+                "not provided",
+            )
+            try:
+                for update in enforce_terms(terms_accepted, *args):
+                    status = update[0] if isinstance(update, tuple) else update
+                    if isinstance(status, str) and any(
+                        marker in status.lower() for marker in failures
+                    ):
+                        gr.Warning(status)
+                    yield update
+            except Exception:
+                gr.Warning(
+                    i18n(
+                        "An error occurred during real-time conversion. Please check the console logs for more details."
+                    )
+                )
+                raise
+
         def update_on_model_change(model_path):
             new_index = match_index(model_path)
             new_sids = get_speakers_id(model_path)
@@ -1996,7 +2027,7 @@ def realtime_tab():
             )
         else:
             start_button.click(
-                fn=enforce_terms,
+                fn=_realtime_with_toast,
                 inputs=[
                     terms_checkbox,
                     input_audio_device,

--- a/tabs/tensorboard/tensorboard.py
+++ b/tabs/tensorboard/tensorboard.py
@@ -9,6 +9,7 @@ def tensorboard_tab():
     def launch_and_get_url():
         url = launch_tensorboard()
         if url and not url.startswith("Error"):
+            gr.Info(i18n("TensorBoard ready."))
             return (
                 url,
                 '<iframe src="/tensorboard/" width="100%" height="800" frameborder="0"></iframe>',

--- a/tabs/voice_blender/voice_blender.py
+++ b/tabs/voice_blender/voice_blender.py
@@ -11,10 +11,30 @@ i18n = I18nAuto()
 
 
 def update_model_fusion(dropbox):
+    gr.Info(i18n("Model added. It is now selected in the 'Path to Model' field."))
     return dropbox, None
 
 
 def voice_blender_tab():
+    def _blend_with_toast(*args):
+        gr.Info(i18n("Blending models..."))
+        try:
+            result = run_model_blender_script(*args)
+        except Exception:
+            gr.Warning(
+                i18n(
+                    "An error occurred blending the models. Please check the console logs for more details."
+                )
+            )
+            raise
+        message = result[0] if isinstance(result, tuple) else result
+        if isinstance(message, str):
+            if "error" in message.lower() or "failed" in message.lower():
+                gr.Warning(message)
+            else:
+                gr.Info(message)
+        return result
+
     gr.Markdown(i18n("## Voice Blender"))
     gr.Markdown(
         i18n(
@@ -75,7 +95,7 @@ def voice_blender_tab():
             )
 
     model_fusion_button.click(
-        fn=run_model_blender_script,
+        fn=_blend_with_toast,
         inputs=[
             model_fusion_name,
             model_fusion_a,


### PR DESCRIPTION
PR #1271 and #1275 cover conversions, TTS, training, preprocessing, extraction and downloads. Five remaining tasks give little or no spoken feedback: blending two models, installing a plugin, the real-time engine, loading model information and launching tensorboard.

This PR adds toasts to all five of them:

- voice blender: announces the mix start, the result and errors, and confirms when a dropped model lands in a slot (a drop is easy to miss when you can't see the field fill in)
- plugin install: start and errors (success toast already exists)
- real time engine: start and failures, including validation messages like "Please select valid input/output devices!", which previously appeared only in the status label
- model information and tensorboard: toast when the info is loaded and when the board is ready

The new messages flow through the existing translation setup. The real time wrapper also warns on the engine's own stop messages ("...Stopping.", "Aborting conversion."), which means the user also gets a spoken alert when a run fails.

Tested successfully on macos with voiceover.