### PR TITLE
Accessibility improvements: add section headings, for screen readers to be able to navigate tabs more easily

### DIFF
--- a/assets/i18n/languages/en_US.json
+++ b/assets/i18n/languages/en_US.json
@@ -1,8 +1,12 @@
 {
     "# How to Report an Issue on GitHub": "# How to Report an Issue on GitHub",
+    "## Advanced Settings": "## Advanced Settings",
+    "## Conversion": "## Conversion",
     "## Download Model": "## Download Model",
     "## Download Pretrained Models": "## Download Pretrained Models",
     "## Drop files": "## Drop files",
+    "## Model Selection": "## Model Selection",
+    "## TTS Settings": "## TTS Settings",
     "## Voice Blender": "## Voice Blender",
     "0 to ∞ separated by -": "0 to ∞ separated by -",
     "1. Click on the 'Record Screen' button below to start recording the issue you are experiencing.": "1. Click on the 'Record Screen' button below to start recording the issue you are experiencing.",

--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -500,6 +500,7 @@ def update_filter_visibility(_):
 def inference_tab():
     trigger = get_filter_trigger()
     with gr.Column():
+        gr.Markdown(value=i18n("## Model Selection"))
         with gr.Row():
             model_file = gr.Dropdown(
                 label=i18n("Voice Model"),
@@ -1196,6 +1197,8 @@ def inference_tab():
                 traceback.print_exc()
                 return "An error occurred during audio batch conversion. Please check the console logs for more details."
 
+        gr.Markdown(value=i18n("## Conversion"))
+
         terms_checkbox = gr.Checkbox(
             label=i18n("I agree to the terms of use"),
             info=i18n(
@@ -1815,6 +1818,8 @@ def inference_tab():
                         move_files_button_batch = gr.Button(
                             i18n("Move files to custom embedder folder")
                         )
+
+        gr.Markdown(value=i18n("## Conversion"))
 
         terms_checkbox_batch = gr.Checkbox(
             label=i18n("I agree to the terms of use"),

--- a/tabs/realtime/realtime.py
+++ b/tabs/realtime/realtime.py
@@ -1131,6 +1131,7 @@ def realtime_tab():
                     )
 
             with gr.TabItem(i18n("Model Settings")):
+                gr.Markdown(value=i18n("## Model Selection"))
                 with gr.Row():
                     model_choices = (
                         sorted(names, key=extract_model_and_epoch) if names else []
@@ -1161,6 +1162,7 @@ def realtime_tab():
                     unload_button = gr.Button(i18n("Unload Voice"))
                     refresh_button = gr.Button(i18n("Refresh models and indexes"))
                 with gr.Column():
+                    gr.Markdown(value=i18n("## Advanced Settings"))
                     autotune = gr.Checkbox(
                         label=i18n("Autotune"),
                         info=i18n(

--- a/tabs/tts/tts.py
+++ b/tabs/tts/tts.py
@@ -51,6 +51,7 @@ def process_input(file_path):
 def tts_tab():
     trigger = get_filter_trigger()
     with gr.Column():
+        gr.Markdown(value=i18n("## Model Selection"))
         with gr.Row():
             model_file = gr.Dropdown(
                 label=i18n("Voice Model"),
@@ -107,6 +108,7 @@ def tts_tab():
                 outputs=[index_file],
             )
 
+    gr.Markdown(value=i18n("## TTS Settings"))
     gr.Markdown(
         i18n(
             f"Applio is a Speech-to-Speech conversion software, utilizing EdgeTTS as middleware for running the Text-to-Speech (TTS) component. Read more about it [here!](https://docs.applio.org/applio/getting-started/tts)"
@@ -374,6 +376,8 @@ def tts_tab():
                 "An error occurred during TTS conversion. Please check the console logs for more details.",
                 None,
             )
+
+    gr.Markdown(value=i18n("## Conversion"))
 
     terms_checkbox = gr.Checkbox(
         label=i18n("I agree to the terms of use"),


### PR DESCRIPTION
Accessibility tools let you jump between sections of a page by iterating through the list of headings. But that only works if the page contains headings, which were missing from some tabs.

The download tab already used `gr.Markdown("## ...")` to mark its sections. This follows the same pattern.

- inference: "Model Selection" at the top, "Conversion" above the run controls, in both the single and the batch tab
- TTS: "Model Selection", "TTS Settings", "Conversion"
- real-time: "Model Selection" and "Advanced Settings" inside the model settings tab

The other tabs were left alone on purpose. Training is five top-level accordions that already have their own titles. The Settings and Extras tabs are small, labeled clusters with named groups.

I have added the new strings in en_US.json as well.

Verified on macos with voiceover.