### PR TITLE
Fix silent data loss in preprocess/extract, make dataset artifacts portable, and isolate the conda env from user site-packages

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,11 @@ import sys
 now_dir = os.getcwd()
 sys.path.append(now_dir)
 
+# Before anything imports a third-party package
+from rvc.lib.user_site import disable_user_site
+
+disable_user_site()
+
 # TODO: This path is regenerated all over the place in Applio
 # should probably be in a static module for everything to reference
 CONFIG_PATH = os.path.join(now_dir, "assets", "config.json")

--- a/core.py
+++ b/core.py
@@ -3,13 +3,18 @@ import os
 import subprocess
 import sys
 
+now_dir = os.getcwd()
+sys.path.append(now_dir)
+
+# Before anything imports a third-party package
+from rvc.lib.user_site import disable_user_site
+
+disable_user_site()
+
 import click
 
 from functools import lru_cache
 from datetime import datetime, timedelta
-
-now_dir = os.getcwd()
-sys.path.append(now_dir)
 
 current_script_directory = os.path.dirname(os.path.realpath(__file__))
 logs_path = os.path.join(current_script_directory, "logs")
@@ -417,6 +422,7 @@ def run_preprocess_script(
     chunk_len: float,
     overlap_len: float,
     normalization_mode: str = "none",
+    dataset_format: str = "wav",
 ):
     preprocess_script_path = os.path.join("rvc", "train", "preprocess", "preprocess.py")
     command = [
@@ -436,6 +442,7 @@ def run_preprocess_script(
                 chunk_len,
                 overlap_len,
                 normalization_mode,
+                dataset_format,
             ],
         ),
     ]
@@ -456,6 +463,9 @@ def run_extract_script(
     embedder_model: str,
     embedder_model_custom: str = None,
     include_mutes: int = 2,
+    remove_16k_slices: bool = False,
+    compact_f0: bool = False,
+    fp16_embeddings: bool = False,
 ):
     model_path = os.path.join(logs_path, model_name)
     extract = os.path.join("rvc", "train", "extract", "extract.py")
@@ -474,6 +484,9 @@ def run_extract_script(
                 embedder_model,
                 embedder_model_custom,
                 include_mutes,
+                remove_16k_slices,
+                compact_f0,
+                fp16_embeddings,
             ],
         ),
     ]
@@ -1055,6 +1068,12 @@ def tts(**kwargs):
     default="none",
     help="Normalization mode.",
 )
+@click.option(
+    "--dataset-format",
+    type=click.Choice(["wav", "flac"]),
+    default="wav",
+    help="Format of the sliced dataset. FLAC is about half the size but is stored as 24-bit PCM.",
+)
 def preprocess(**kwargs):
     """Preprocess a dataset for training."""
     kwargs["sample_rate"] = int(kwargs["sample_rate"])
@@ -1074,6 +1093,7 @@ def preprocess(**kwargs):
         chunk_len=kwargs["chunk_len"],
         overlap_len=kwargs["overlap_len"],
         normalization_mode=kwargs["normalization_mode"],
+        dataset_format=kwargs["dataset_format"],
     )
     click.echo(result)
 
@@ -1124,6 +1144,24 @@ def preprocess(**kwargs):
     default=2,
     help="Number of silent files to include.",
 )
+@click.option(
+    "--remove-16k-slices",
+    is_flag=True,
+    default=False,
+    help="Delete sliced_audios_16k once the features are extracted. Re-extracting needs preprocessing again.",
+)
+@click.option(
+    "--compact-f0",
+    is_flag=True,
+    default=False,
+    help="Store coarse pitch as uint8 instead of int64 (an eighth of the disk, same values).",
+)
+@click.option(
+    "--fp16-embeddings",
+    is_flag=True,
+    default=False,
+    help="Run the embedder forward pass in float16 on CUDA. Features are still stored as float32.",
+)
 def extract(**kwargs):
     """Extract features from a preprocessed dataset."""
     kwargs["sample_rate"] = int(kwargs["sample_rate"])
@@ -1137,6 +1175,9 @@ def extract(**kwargs):
         embedder_model=kwargs["embedder_model"],
         embedder_model_custom=kwargs["embedder_model_custom"],
         include_mutes=kwargs["include_mutes"],
+        remove_16k_slices=kwargs["remove_16k_slices"],
+        compact_f0=kwargs["compact_f0"],
+        fp16_embeddings=kwargs["fp16_embeddings"],
     )
     click.echo(result)
 

--- a/run-applio.bat
+++ b/run-applio.bat
@@ -9,6 +9,7 @@ if /i "%cd%"=="C:\Windows\System32" (
 )
 
 setlocal
+set PYTHONNOUSERSITE=1
 for %%F in ("%~dp0.") do set "folder_name=%%~nF"
 
 title %folder_name%

--- a/run-applio.sh
+++ b/run-applio.sh
@@ -2,6 +2,7 @@
 printf "\033]0;Applio\007"
 . .venv/bin/activate
 
+export PYTHONNOUSERSITE=1
  export PYTORCH_ENABLE_MPS_FALLBACK=1
  export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
  

--- a/run-install.bat
+++ b/run-install.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
+set PYTHONNOUSERSITE=1
 title Applio Installer
 
 echo Welcome to the Applio Installer!

--- a/run-install.sh
+++ b/run-install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e # Exit immediately if a command exits with a non-zero status
+export PYTHONNOUSERSITE=1
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'

--- a/run-tensorboard.bat
+++ b/run-tensorboard.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal
+set PYTHONNOUSERSITE=1
 title Tensorboard
 
 if not exist env (

--- a/run-tensorboard.sh
+++ b/run-tensorboard.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 printf "\033]0;Tensorboard\007"
 . .venv/bin/activate
+export PYTHONNOUSERSITE=1
 
 clear
 python core.py tensorboard

--- a/rvc/lib/user_site.py
+++ b/rvc/lib/user_site.py
@@ -1,0 +1,34 @@
+import os
+import site
+import sys
+
+
+def disable_user_site():
+    """
+    Removes the per-user site-packages directory from this process.
+
+    Applio's env is a conda prefix rather than a venv, and conda honours the
+    per-user site-packages directory, so packages installed there for an
+    unrelated project shadow Applio's own versions. The environment variable
+    carries the same isolation into the subprocesses spawned for training.
+    """
+    os.environ["PYTHONNOUSERSITE"] = "1"
+    if not getattr(site, "ENABLE_USER_SITE", False):
+        return []
+
+    try:
+        user_paths = site.getusersitepackages()
+    except Exception:
+        return []
+    if isinstance(user_paths, str):
+        user_paths = [user_paths]
+    targets = {os.path.normcase(os.path.abspath(p)) for p in user_paths}
+
+    removed = [p for p in sys.path if os.path.normcase(os.path.abspath(p)) in targets]
+    for path in removed:
+        sys.path.remove(path)
+    site.ENABLE_USER_SITE = False
+
+    if removed:
+        print(f"Ignoring user site-packages: {removed[0]}")
+    return removed

--- a/rvc/train/data_utils.py
+++ b/rvc/train/data_utils.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+import soundfile as sf
 import torch
 import torch.utils.data
 
@@ -36,9 +37,29 @@ class TextAudioLoaderMultiNSFsid(torch.utils.data.Dataset):
         for audiopath, text, pitch, pitchf, dv in self.audiopaths_and_text:
             if self.min_text_len <= len(text) and len(text) <= self.max_text_len:
                 audiopaths_and_text_new.append([audiopath, text, pitch, pitchf, dv])
-                lengths.append(os.path.getsize(audiopath) // (3 * self.hop_length))
+                lengths.append(self._slice_length(audiopath))
         self.audiopaths_and_text = audiopaths_and_text_new
         self.lengths = lengths
+
+    def _slice_length(self, audiopath):
+        """
+        Approximates slice length in the units the bucket boundaries use.
+
+        A compressed format breaks the size-to-duration proportionality, so its
+        frame count is scaled by the four bytes per sample a wav would have
+        used. Both formats have to land on the same scale, since a slice outside
+        the boundaries is dropped from training entirely.
+
+        Args:
+            audiopath (str): Path to the sliced audio file.
+        """
+        if audiopath.lower().endswith(".wav"):
+            return os.path.getsize(audiopath) // (3 * self.hop_length)
+        try:
+            return (sf.info(audiopath).frames * 4) // (3 * self.hop_length)
+        except Exception as error:
+            print(f"Could not read the length of {audiopath}: {error}")
+            return os.path.getsize(audiopath) // (3 * self.hop_length)
 
     def get_sid(self, sid):
         """
@@ -104,7 +125,8 @@ class TextAudioLoaderMultiNSFsid(torch.utils.data.Dataset):
         pitch = pitch[:n_num]
         pitchf = pitchf[:n_num]
         phone = torch.FloatTensor(phone)
-        pitch = torch.LongTensor(pitch)
+        # coarse pitch may have been stored as uint8 by a compact extraction
+        pitch = torch.LongTensor(pitch.astype(np.int64, copy=False))
         pitchf = torch.FloatTensor(pitchf)
         return phone, pitch, pitchf
 
@@ -122,7 +144,7 @@ class TextAudioLoaderMultiNSFsid(torch.utils.data.Dataset):
             )
         audio_norm = audio
         audio_norm = audio_norm.unsqueeze(0)
-        spec_filename = filename.replace(".wav", ".spec.pt")
+        spec_filename = os.path.splitext(filename)[0] + ".spec.pt"
         if os.path.exists(spec_filename):
             try:
                 spec = torch.load(spec_filename, weights_only=True)

--- a/rvc/train/extract/extract.py
+++ b/rvc/train/extract/extract.py
@@ -3,6 +3,7 @@ import glob
 import json
 import multiprocessing as mp
 import os
+import shutil
 import sys
 import time
 
@@ -24,9 +25,16 @@ from rvc.train.extract.preparing_files import generate_config, generate_filelist
 config = Config()
 mp.set_start_method("spawn", force=True)
 
+# formats the preprocessor may have written the slices in
+AUDIO_EXTENSIONS = (".wav", ".flac")
+
+
+def strtobool(value: str) -> bool:
+    return str(value).lower() in ("yes", "true", "t", "y", "1")
+
 
 class FeatureInput:
-    def __init__(self, f0_method="rmvpe", device="cpu"):
+    def __init__(self, f0_method="rmvpe", device="cpu", compact_f0=False):
         self.hop_size = 160  # default
         self.sample_rate = 16000  # default
         self.f0_bin = 256
@@ -35,6 +43,9 @@ class FeatureInput:
         self.f0_mel_min = 1127 * np.log(1 + self.f0_min / 700)
         self.f0_mel_max = 1127 * np.log(1 + self.f0_max / 700)
         self.device = device
+        # coarse pitch is a bucket index clipped to [1, 255], so uint8 holds it
+        # exactly at an eighth of the int64 size
+        self.coarse_dtype = np.uint8 if compact_f0 else int
         if f0_method in ("crepe", "crepe-tiny"):
             self.model = CREPE(
                 device=self.device, sample_rate=self.sample_rate, hop_size=self.hop_size
@@ -79,7 +90,7 @@ class FeatureInput:
             1,
             self.f0_bin - 1,
         )
-        return np.rint(f0_mel).astype(int)
+        return np.rint(f0_mel).astype(self.coarse_dtype)
 
     def process_file(self, file_info):
         inp_path, opt_path_coarse, opt_path_full, _ = file_info
@@ -98,15 +109,17 @@ class FeatureInput:
             )
 
 
-def process_files(files, f0_method, device, threads):
-    fe = FeatureInput(f0_method=f0_method, device=device)
+def process_files(files, f0_method, device, threads, compact_f0=False):
+    if device == "cpu":
+        torch.set_num_threads(max(1, threads))
+    fe = FeatureInput(f0_method=f0_method, device=device, compact_f0=compact_f0)
     with tqdm.tqdm(total=len(files), leave=True) as pbar:
         for file_info in files:
             fe.process_file(file_info)
             pbar.update(1)
 
 
-def run_pitch_extraction(files, devices, f0_method, threads):
+def run_pitch_extraction(files, devices, f0_method, threads, compact_f0=False):
     devices_str = ", ".join(devices)
     print(f"Starting pitch extraction on {devices_str} using {f0_method}...")
     start_time = time.time()
@@ -119,20 +132,34 @@ def run_pitch_extraction(files, devices, f0_method, threads):
                 f0_method,
                 devices[i],
                 threads // len(devices),
+                compact_f0,
             )
             for i in range(len(devices))
         ]
-        concurrent.futures.wait(tasks)
+        # .result() is what makes a worker crash reach this process, otherwise
+        # extraction reports success over a half-built dataset
+        for task in concurrent.futures.as_completed(tasks):
+            task.result()
 
     print(f"Pitch extraction completed in {time.time() - start_time:.2f} seconds.")
 
 
 def process_file_embedding(
-    files, embedder_model, embedder_model_custom, device_num, device, n_threads
+    files,
+    embedder_model,
+    embedder_model_custom,
+    device_num,
+    device,
+    n_threads,
+    fp16_embeddings=False,
 ):
     model = load_embedding(embedder_model, embedder_model_custom).to(device).float()
     model.eval()
     n_threads = max(1, n_threads)
+    if device == "cpu":
+        torch.set_num_threads(n_threads)
+    # half precision on the forward pass only, the result is stored as float32
+    use_amp = fp16_embeddings and str(device).startswith("cuda")
 
     def worker(file_info):
         wav_file_path, _, _, out_file_path = file_info
@@ -140,23 +167,31 @@ def process_file_embedding(
             return
         feats = torch.from_numpy(load_audio_16k(wav_file_path)).to(device).float()
         feats = feats.view(1, -1)
-        with torch.no_grad():
+        with torch.autocast(device_type="cuda", dtype=torch.float16, enabled=use_amp):
             result = model(feats)["last_hidden_state"]
         feats_out = result.squeeze(0).float().cpu().numpy()
-        if not np.isnan(feats_out).any():
+        # inf is as unusable as nan downstream, and an isnan check misses it
+        if np.isfinite(feats_out).all():
             np.save(out_file_path, feats_out, allow_pickle=False)
         else:
-            print(f"{wav_file_path} produced NaN values; skipping.")
+            print(f"{wav_file_path} produced non-finite values; skipping.")
 
+    # one file at a time: threads here shared a single CUDA model, contending
+    # for the GIL while each in-flight file added its own VRAM peak
     with tqdm.tqdm(total=len(files), leave=True, position=device_num) as pbar:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=n_threads) as executor:
-            futures = [executor.submit(worker, f) for f in files]
-            for _ in concurrent.futures.as_completed(futures):
+        with torch.no_grad():
+            for file_info in files:
+                worker(file_info)
                 pbar.update(1)
 
 
 def run_embedding_extraction(
-    files, devices, embedder_model, embedder_model_custom, threads
+    files,
+    devices,
+    embedder_model,
+    embedder_model_custom,
+    threads,
+    fp16_embeddings=False,
 ):
     devices_str = ", ".join(devices)
     print(
@@ -173,12 +208,62 @@ def run_embedding_extraction(
                 i,
                 devices[i],
                 threads // len(devices),
+                fp16_embeddings,
             )
             for i in range(len(devices))
         ]
-        concurrent.futures.wait(tasks)
+        for task in concurrent.futures.as_completed(tasks):
+            task.result()
 
     print(f"Embedding extraction completed in {time.time() - start_time:.2f} seconds.")
+
+
+def discard_16k_slices(wav_path):
+    """
+    Deletes the 16 kHz slices once the features derived from them exist.
+
+    They feed pitch and embedder extraction only, so training never reads them.
+    Re-extracting afterwards means preprocessing the dataset again.
+
+    Args:
+        wav_path (str): Path to the sliced_audios_16k directory.
+    """
+    if os.path.basename(os.path.normpath(wav_path)) != "sliced_audios_16k":
+        return
+    if not os.path.isdir(wav_path):
+        return
+
+    # the mute folders are shared by every model that includes silent files
+    experiment_name = os.path.basename(os.path.dirname(os.path.normpath(wav_path)))
+    if experiment_name.lower().startswith("mute"):
+        print(f"Keeping 16 kHz slices: '{experiment_name}' is a shared mute asset.")
+        return
+
+    # only discard once the artifacts that replace them are on disk
+    exp_dir = os.path.dirname(os.path.normpath(wav_path))
+    if not os.path.isfile(os.path.join(exp_dir, "filelist.txt")):
+        print(
+            "Keeping 16 kHz slices: filelist.txt is missing, so extraction looks incomplete."
+        )
+        return
+
+    freed = 0
+    count = 0
+    for root, _, names in os.walk(wav_path):
+        for name in names:
+            try:
+                freed += os.path.getsize(os.path.join(root, name))
+                count += 1
+            except OSError:
+                pass
+
+    try:
+        shutil.rmtree(wav_path)
+    except OSError as error:
+        print(f"Could not remove the 16 kHz slices: {error}")
+        return
+
+    print(f"Removed {count} 16 kHz slices, freeing {freed / (1024 ** 3):.2f} GB.")
 
 
 if __name__ == "__main__":
@@ -190,6 +275,9 @@ if __name__ == "__main__":
     embedder_model = sys.argv[6]
     embedder_model_custom = sys.argv[7] if len(sys.argv) > 7 else None
     include_mutes = int(sys.argv[8]) if len(sys.argv) > 8 else 2
+    remove_16k_slices = strtobool(sys.argv[9]) if len(sys.argv) > 9 else False
+    compact_f0 = strtobool(sys.argv[10]) if len(sys.argv) > 10 else False
+    fp16_embeddings = strtobool(sys.argv[11]) if len(sys.argv) > 11 else False
 
     wav_path = os.path.join(exp_dir, "sliced_audios_16k")
 
@@ -216,14 +304,22 @@ if __name__ == "__main__":
     with open(file_path, "w") as f:
         json.dump(data, f, indent=4)
 
+    audio_files = [
+        path
+        for path in glob.glob(os.path.join(wav_path, "*"))
+        if os.path.isfile(path) and path.lower().endswith(AUDIO_EXTENSIONS)
+    ]
+    # longest first, so the strided split leaves every device a similar total
+    audio_files.sort(key=os.path.getsize, reverse=True)
+
     files = []
-    for file in glob.glob(os.path.join(wav_path, "*.wav")):
+    for file in audio_files:
         file_name = os.path.basename(file)
         file_info = [
             file,
             os.path.join(exp_dir, "f0", file_name + ".npy"),
             os.path.join(exp_dir, "f0_voiced", file_name + ".npy"),
-            os.path.join(exp_dir, "extracted", file_name.replace("wav", "npy")),
+            os.path.join(exp_dir, "extracted", os.path.splitext(file_name)[0] + ".npy"),
         ]
         files.append(file_info)
 
@@ -235,11 +331,19 @@ if __name__ == "__main__":
 
     devices = ["cpu"] if gpus == "-" else [f"cuda:{idx}" for idx in gpus.split("-")]
 
-    run_pitch_extraction(files, devices, f0_method, num_processes)
+    run_pitch_extraction(files, devices, f0_method, num_processes, compact_f0)
 
     run_embedding_extraction(
-        files, devices, embedder_model, embedder_model_custom, num_processes
+        files,
+        devices,
+        embedder_model,
+        embedder_model_custom,
+        num_processes,
+        fp16_embeddings,
     )
 
     generate_config(sample_rate, exp_dir)
     generate_filelist(exp_dir, sample_rate, include_mutes)
+
+    if remove_16k_slices:
+        discard_16k_slices(wav_path)

--- a/rvc/train/extract/preparing_files.py
+++ b/rvc/train/extract/preparing_files.py
@@ -7,6 +7,49 @@ import json
 config = Config()
 current_directory = os.getcwd()
 
+# Filelist paths are stored relative to this. Absolute paths bake in the
+# machine that ran the extraction, and paths relative to the working directory
+# break whenever training is launched from elsewhere. Derived from this file
+# rather than os.getcwd() because the extractor runs as a subprocess.
+APPLICATION_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
+
+def relative_to_root(path: str) -> str:
+    """
+    Returns a path relative to the application root, with forward slashes.
+
+    POSIX separators keep a preprocessed logs directory portable between
+    platforms. A path outside the root is returned absolute.
+
+    Args:
+        path (str): The path to rewrite.
+    """
+    absolute = os.path.abspath(path)
+    try:
+        relative = os.path.relpath(absolute, APPLICATION_ROOT)
+    except ValueError:
+        # Different drive on Windows; no relative path exists.
+        return absolute.replace(os.sep, "/")
+    if relative.startswith(os.pardir):
+        return absolute.replace(os.sep, "/")
+    return relative.replace(os.sep, "/")
+
+
+def _by_stem(directory: str) -> dict:
+    """
+    Maps every file in a directory to its slice name.
+
+    Slice names never contain a dot, so 0_0_0.wav, 0_0_0.flac, 0_0_0.wav.npy
+    and 0_0_0.npy all resolve to 0_0_0. Keeping the real filename is what lets
+    the dataset be written in a format other than wav.
+
+    Args:
+        directory (str): Directory to list.
+    """
+    return {name.split(".")[0]: name for name in os.listdir(directory)}
+
 
 def generate_config(sample_rate: int, model_path: str):
     config_path = os.path.join("rvc", "configs", f"{sample_rate}.json")
@@ -23,12 +66,12 @@ def generate_filelist(model_path: str, sample_rate: int, include_mutes: int = 2)
     f0_dir = os.path.join(model_path, "f0")
     f0nsf_dir = os.path.join(model_path, "f0_voiced")
 
-    gt_wavs_files = set(name.split(".")[0] for name in os.listdir(gt_wavs_dir))
-    feature_files = set(name.split(".")[0] for name in os.listdir(feature_dir))
+    gt_wavs_files = _by_stem(gt_wavs_dir)
+    feature_files = _by_stem(feature_dir)
+    f0_files = _by_stem(f0_dir)
+    f0nsf_files = _by_stem(f0nsf_dir)
 
-    f0_files = set(name.split(".")[0] for name in os.listdir(f0_dir))
-    f0nsf_files = set(name.split(".")[0] for name in os.listdir(f0nsf_dir))
-    names = gt_wavs_files & feature_files & f0_files & f0nsf_files
+    names = set(gt_wavs_files) & set(feature_files) & set(f0_files) & set(f0nsf_files)
 
     try:
         model_info_path = os.path.join(model_path, "model_info.json")
@@ -52,35 +95,39 @@ def generate_filelist(model_path: str, sample_rate: int, include_mutes: int = 2)
         if sid not in sids:
             sids.append(sid)
 
-        # Calculate relative pathing
-        rel_wav = os.path.relpath(f"{os.path.join(gt_wavs_dir, name)}.wav")
-        rel_feat = os.path.relpath(f"{os.path.join(feature_dir, name)}.npy")
-        rel_f0 = os.path.relpath(f"{os.path.join(f0_dir, name)}.wav.npy")
-        rel_f0nsf = os.path.relpath(f"{os.path.join(f0nsf_dir, name)}.wav.npy")
-
         options.append(
-            f"{rel_wav}|{rel_feat}|{rel_f0}|{rel_f0nsf}|{sid}".replace("\\", "/")
+            "|".join(
+                (
+                    relative_to_root(os.path.join(gt_wavs_dir, gt_wavs_files[name])),
+                    relative_to_root(os.path.join(feature_dir, feature_files[name])),
+                    relative_to_root(os.path.join(f0_dir, f0_files[name])),
+                    relative_to_root(os.path.join(f0nsf_dir, f0nsf_files[name])),
+                    sid,
+                )
+            )
         )
 
     if include_mutes > 0:
-        mute_audio_path = os.path.relpath(
-            os.path.join(mute_base_path, "sliced_audios", f"mute{sample_rate}.wav")
-        )
-        mute_feature_path = os.path.relpath(
-            os.path.join(mute_base_path, f"extracted", "mute.npy")
-        )
-        mute_f0_path = os.path.relpath(
-            os.path.join(mute_base_path, "f0", "mute.wav.npy")
-        )
-        mute_f0nsf_path = os.path.relpath(
-            os.path.join(mute_base_path, "f0_voiced", "mute.wav.npy")
+        mute_entry = "|".join(
+            (
+                relative_to_root(
+                    os.path.join(
+                        mute_base_path, "sliced_audios", f"mute{sample_rate}.wav"
+                    )
+                ),
+                relative_to_root(
+                    os.path.join(mute_base_path, f"extracted", "mute.npy")
+                ),
+                relative_to_root(os.path.join(mute_base_path, "f0", "mute.wav.npy")),
+                relative_to_root(
+                    os.path.join(mute_base_path, "f0_voiced", "mute.wav.npy")
+                ),
+            )
         )
 
         # adding x files per sid
         for sid in sids * include_mutes:
-            options.append(
-                f"{mute_audio_path}|{mute_feature_path}|{mute_f0_path}|{mute_f0nsf_path}|{sid}"
-            )
+            options.append(f"{mute_entry}|{sid}")
 
     file_path = os.path.join(model_path, "model_info.json")
     if os.path.exists(file_path):

--- a/rvc/train/preprocess/preprocess.py
+++ b/rvc/train/preprocess/preprocess.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import sys
 import time
+from fractions import Fraction
 
 
 def strtobool(val):
@@ -14,6 +15,7 @@ def strtobool(val):
 import librosa
 import noisereduce as nr
 import numpy as np
+import soundfile as sf
 import soxr
 from scipy import signal
 from scipy.io import wavfile
@@ -39,9 +41,67 @@ HIGH_PASS_CUTOFF = 48
 SAMPLE_RATE_16K = 16000
 RES_TYPE = "soxr_vhq"
 
+# shortest tail worth keeping as its own slice in "Simple" cutting
+MIN_TAIL_SECONDS = 1.0
+
+# wav is float32 with no level ceiling, flac is half the size but 24-bit PCM
+DATASET_FORMATS = ("wav", "flac")
+FLAC_COMPRESSION_LEVEL = 5 / 8  # libsndfile takes 0.0-1.0; this is FLAC level 5
+
+
+def secs_to_samples(seconds: float, sr: int) -> int:
+    """
+    Converts seconds to an exact sample count, refusing fractional results.
+
+    `int(sr * seconds)` truncates, so a chunk and its overlap can disagree by a
+    sample and the stride drifts across a long file.
+
+    Args:
+        seconds (float): Duration to convert.
+        sr (int): Sampling rate.
+    """
+    frac = Fraction(str(seconds)) * sr
+    if frac.denominator != 1:
+        raise ValueError(f"{seconds}s at {sr} Hz is not a whole number of samples.")
+    return frac.numerator
+
+
+def save_audio(
+    directory: str,
+    name: str,
+    sample_rate: int,
+    dataset_format: str,
+    audio: np.ndarray,
+):
+    """
+    Writes one slice in the requested dataset format.
+
+    Args:
+        directory (str): Directory to write into.
+        name (str): File name without the extension.
+        sample_rate (int): Sampling rate of the audio.
+        dataset_format (str): Either "wav" or "flac".
+        audio (np.ndarray): Audio data array.
+    """
+    if dataset_format == "flac":
+        sf.write(
+            os.path.join(directory, f"{name}.flac"),
+            audio,
+            sample_rate,
+            format="FLAC",
+            subtype="PCM_24",
+            compression_level=FLAC_COMPRESSION_LEVEL,
+        )
+    else:
+        wavfile.write(
+            os.path.join(directory, f"{name}.wav"),
+            sample_rate,
+            audio.astype(np.float32),
+        )
+
 
 class PreProcess:
-    def __init__(self, sr: int, exp_dir: str):
+    def __init__(self, sr: int, exp_dir: str, dataset_format: str = "wav"):
         self.slicer = Slicer(
             sr=sr,
             threshold=-42,
@@ -51,9 +111,13 @@ class PreProcess:
             max_sil_kept=500,
         )
         self.sr = sr
-        self.b_high, self.a_high = signal.butter(
-            N=5, Wn=HIGH_PASS_CUTOFF, btype="high", fs=self.sr
+        self.dataset_format = dataset_format
+        # sos rather than ba: at 48 Hz the poles sit at |p| = 0.998, which makes
+        # the transfer-function form badly conditioned
+        self.hp_sos = signal.butter(
+            N=5, Wn=HIGH_PASS_CUTOFF, btype="high", fs=self.sr, output="sos"
         )
+        self.hp_zi = signal.sosfilt_zi(self.hp_sos)
         self.exp_dir = exp_dir
         self.device = "cpu"
         self.gt_wavs_dir = os.path.join(exp_dir, "sliced_audios")
@@ -61,11 +125,52 @@ class PreProcess:
         os.makedirs(self.gt_wavs_dir, exist_ok=True)
         os.makedirs(self.wavs16k_dir, exist_ok=True)
 
+    def high_pass(self, audio: np.ndarray) -> np.ndarray:
+        """
+        Removes DC offset and subsonic rumble.
+
+        The filter state is primed with the mean of the opening window instead
+        of starting at zero, which would read a DC offset as a step and leave a
+        ~45 ms thump at the head of the first slice of every file.
+
+        Args:
+            audio (np.ndarray): Audio data array.
+        """
+        if audio.size == 0:
+            return audio
+        # the pole time constant is 3.3 ms, so 20 ms is enough to estimate DC
+        window = min(audio.size, int(0.02 * self.sr))
+        prime = float(np.mean(audio[:window]))
+        filtered, _ = signal.sosfilt(self.hp_sos, audio, zi=self.hp_zi * prime)
+        # sosfilt promotes to float64, the rest of the pipeline is float32
+        return filtered.astype(np.float32, copy=False)
+
     def _normalize_audio(self, audio: np.ndarray):
         tmp_max = np.abs(audio).max()
         if tmp_max > 2.5:
             return None
+        if tmp_max == 0:
+            # digital silence, dividing by the peak would fill the slice with NaN
+            return audio
         return (audio / tmp_max * (MAX_AMPLITUDE * ALPHA)) + (1 - ALPHA) * audio
+
+    def _fit_to_flac(self, audio: np.ndarray, audio_16k: np.ndarray, label: str):
+        """
+        Scales a slice pair down so 24-bit PCM can hold it.
+
+        FLAC clips outside [-1, 1] and the peak blend above can reach 1.3. Both
+        copies take the same factor so they stay level-matched.
+
+        Args:
+            audio (np.ndarray): Full rate slice.
+            audio_16k (np.ndarray): The 16 kHz copy of the same slice.
+            label (str): Slice name, for the warning.
+        """
+        peak = max(float(np.abs(audio).max()), float(np.abs(audio_16k).max()))
+        if peak <= 1.0:
+            return audio, audio_16k
+        print(f"{label}: peak {peak:.2f} scaled down to fit 24-bit FLAC.")
+        return audio / peak, audio_16k / peak
 
     def process_audio_segment(
         self,
@@ -75,26 +180,32 @@ class PreProcess:
         idx1: int,
         normalization_mode: str,
     ):
-        if normalized_audio is None:
+        if normalized_audio is None or normalized_audio.size == 0:
             print(f"{sid}-{idx0}-{idx1}-filtered")
             return
         if normalization_mode == "post":
             normalized_audio = self._normalize_audio(normalized_audio)
-        wavfile.write(
-            os.path.join(self.gt_wavs_dir, f"{sid}_{idx0}_{idx1}.wav"),
-            self.sr,
-            normalized_audio.astype(np.float32),
-        )
+            if normalized_audio is None:
+                print(f"{sid}-{idx0}-{idx1}-filtered")
+                return
         audio_16k = librosa.resample(
             normalized_audio,
             orig_sr=self.sr,
             target_sr=SAMPLE_RATE_16K,
             res_type=RES_TYPE,
         )
-        wavfile.write(
-            os.path.join(self.wavs16k_dir, f"{sid}_{idx0}_{idx1}.wav"),
-            SAMPLE_RATE_16K,
-            audio_16k.astype(np.float32),
+        name = f"{sid}_{idx0}_{idx1}"
+        if self.dataset_format == "flac":
+            normalized_audio, audio_16k = self._fit_to_flac(
+                normalized_audio, audio_16k, name
+            )
+        # full SR for training
+        save_audio(
+            self.gt_wavs_dir, name, self.sr, self.dataset_format, normalized_audio
+        )
+        # 16KHz for feature extraction
+        save_audio(
+            self.wavs16k_dir, name, SAMPLE_RATE_16K, self.dataset_format, audio_16k
         )
 
     def simple_cut(
@@ -106,36 +217,46 @@ class PreProcess:
         overlap_len: float,
         normalization_mode: str,
     ):
-        chunk_length = int(self.sr * chunk_len)
-        overlap_length = int(self.sr * overlap_len)
-        i = 0
-        while i < len(audio):
-            chunk = audio[i : i + chunk_length]
-            if normalization_mode == "post":
-                chunk = self._normalize_audio(chunk)
-            if len(chunk) == chunk_length:
-                # full SR for training
-                wavfile.write(
-                    os.path.join(
-                        self.gt_wavs_dir,
-                        f"{sid}_{idx0}_{i // (chunk_length - overlap_length)}.wav",
-                    ),
-                    self.sr,
-                    chunk.astype(np.float32),
-                )
-                # 16KHz for feature extraction
-                chunk_16k = librosa.resample(
-                    chunk, orig_sr=self.sr, target_sr=SAMPLE_RATE_16K, res_type=RES_TYPE
-                )
-                wavfile.write(
-                    os.path.join(
-                        self.wavs16k_dir,
-                        f"{sid}_{idx0}_{i // (chunk_length - overlap_length)}.wav",
-                    ),
-                    SAMPLE_RATE_16K,
-                    chunk_16k.astype(np.float32),
-                )
-            i += chunk_length - overlap_length
+        chunk_length = secs_to_samples(chunk_len, self.sr)
+        overlap_length = secs_to_samples(overlap_len, self.sr)
+        stride = chunk_length - overlap_length
+        if stride <= 0:
+            # a non-positive stride writes slices until the disk fills
+            raise ValueError(
+                "Simple cutting needs overlap_len < chunk_len, got "
+                f"chunk_len={chunk_len}s overlap_len={overlap_len}s."
+            )
+
+        total = len(audio)
+        min_tail = secs_to_samples(MIN_TAIL_SECONDS, self.sr)
+        slice_idx = 0
+        last_start = None
+
+        for start in range(0, total, stride):
+            end = start + chunk_length
+            if end > total:
+                # slide the last window back so it ends on the final sample,
+                # rather than dropping the tail or padding it with silence
+                remainder = total - start
+                if remainder < min_tail:
+                    break
+                if total >= chunk_length:
+                    start = total - chunk_length
+                    if last_start is not None and start <= last_start:
+                        break  # the re-anchored window would repeat the previous one
+                    chunk = audio[start:]
+                else:
+                    # shorter than one chunk, and variable lengths are fine downstream
+                    chunk = audio
+            else:
+                chunk = audio[start:end]
+
+            self.process_audio_segment(chunk, sid, idx0, slice_idx, normalization_mode)
+            last_start = start
+            slice_idx += 1
+
+            if start + chunk_length >= total:
+                break
 
     def process_audio(
         self,
@@ -156,9 +277,15 @@ class PreProcess:
             audio_length = librosa.get_duration(y=audio, sr=self.sr)
 
             if process_effects:
-                audio = signal.lfilter(self.b_high, self.a_high, audio)
+                audio = self.high_pass(audio)
             if normalization_mode == "pre":
-                audio = self._normalize_audio(audio)
+                normalized = self._normalize_audio(audio)
+                if normalized is None:
+                    # letting the None travel on becomes a TypeError that the
+                    # handler below reports as a generic processing error
+                    print(f"Skipping {path}: peak too high to normalize.")
+                    return 0
+                audio = normalized
             if noise_reduction:
                 audio = nr.reduce_noise(
                     y=audio, sr=self.sr, prop_decrease=reduction_strength
@@ -229,7 +356,7 @@ def format_duration(seconds):
     return f"{hours:02}:{minutes:02}:{seconds:02}"
 
 
-def save_dataset_duration(file_path, dataset_duration):
+def save_dataset_duration(file_path, dataset_duration, dataset_format="wav"):
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             data = json.load(f)
@@ -240,11 +367,29 @@ def save_dataset_duration(file_path, dataset_duration):
     new_data = {
         "total_dataset_duration": formatted_duration,
         "total_seconds": dataset_duration,
+        "dataset_format": dataset_format,
     }
     data.update(new_data)
 
     with open(file_path, "w") as f:
         json.dump(data, f, indent=4)
+
+
+def speaker_id_from_directory(root: str, input_root: str) -> int:
+    """
+    Returns the speaker id for a dataset subfolder.
+
+    The root folder itself is speaker 0. A subfolder names its id with a leading
+    integer, so both "3" and "3_maria" work.
+
+    Args:
+        root (str): The subfolder being read.
+        input_root (str): Root of the dataset.
+    """
+    if os.path.normpath(root) == os.path.normpath(input_root):
+        return 0
+    name = os.path.basename(os.path.normpath(root))
+    return int(name.split("_")[0])
 
 
 def process_audio_wrapper(args):
@@ -286,6 +431,7 @@ def preprocess_training_set(
     chunk_len: float,
     overlap_len: float,
     normalization_mode: str,
+    dataset_format: str = "wav",
 ):
     if not os.path.exists(input_root):
         print(f"The dataset path does not exist: '{input_root}'.")
@@ -294,31 +440,79 @@ def preprocess_training_set(
     if not os.path.isdir(input_root):
         print(f"The dataset path is not a directory: '{input_root}'.")
         sys.exit(1)
+
+    if dataset_format not in DATASET_FORMATS:
+        print(
+            f"Unknown dataset format '{dataset_format}'. "
+            f"Expected one of: {', '.join(DATASET_FORMATS)}."
+        )
+        sys.exit(1)
+
+    if cut_preprocess == "Simple":
+        if overlap_len >= chunk_len:
+            print(
+                "Simple cutting needs overlap_len < chunk_len, got "
+                f"chunk_len={chunk_len}s overlap_len={overlap_len}s."
+            )
+            sys.exit(1)
+        try:
+            # checked once here so a bad length is not reported per file
+            secs_to_samples(chunk_len, sr)
+            secs_to_samples(overlap_len, sr)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
+
     start_time = time.time()
-    pp = PreProcess(sr, exp_dir)
+    pp = PreProcess(sr, exp_dir, dataset_format)
     print(f"Starting preprocess with {num_processes} processes...")
 
     files = []
     idx = 0
+    speaker_ids = set()
 
     for root, _, filenames in os.walk(input_root):
+        audio_files = [
+            f
+            for f in filenames
+            if f.lower().endswith((".wav", ".mp3", ".flac", ".ogg"))
+        ]
+        if not audio_files:
+            continue
         try:
-            sid = 0 if root == input_root else int(os.path.basename(root))
-            for f in filenames:
-                if f.lower().endswith((".wav", ".mp3", ".flac", ".ogg")):
-                    files.append((os.path.join(root, f), idx, sid))
-                    idx += 1
+            sid = speaker_id_from_directory(root, input_root)
         except ValueError:
             print(
-                f'Speaker ID folder is expected to be integer, got "{os.path.basename(root)}" instead.'
+                "Speaker ID folders must start with an integer, got "
+                f'"{os.path.basename(os.path.normpath(root))}" instead. '
+                "Name them '0', '1', ... or '0_name', '1_name', ..."
             )
+            sys.exit(1)
+        speaker_ids.add(sid)
+        for f in audio_files:
+            files.append((os.path.join(root, f), idx, sid))
+            idx += 1
 
-    # print(f"Number of files: {len(files)}")
     if len(files) == 0:
         print(
             f"No audio files found in the dataset path: '{input_root}'. Please check that the path is correct and contains valid audio files."
         )
         sys.exit(1)
+
+    # the speaker embedding is sized from the number of distinct ids, so a gap
+    # indexes past the end of that table once training starts
+    expected_ids = set(range(len(speaker_ids)))
+    if speaker_ids != expected_ids:
+        missing = sorted(expected_ids - speaker_ids)
+        print(
+            f"Speaker IDs must be contiguous and start at 0. "
+            f"Found: {sorted(speaker_ids)}. Missing: {missing}."
+        )
+        sys.exit(1)
+
+    if len(speaker_ids) > 1:
+        print(f"Found {len(speaker_ids)} speakers.")
+
     audio_length = []
     with tqdm(total=len(files)) as pbar:
         with concurrent.futures.ProcessPoolExecutor(
@@ -347,7 +541,9 @@ def preprocess_training_set(
 
     audio_length = sum(audio_length)
     save_dataset_duration(
-        os.path.join(exp_dir, "model_info.json"), dataset_duration=audio_length
+        os.path.join(exp_dir, "model_info.json"),
+        dataset_duration=audio_length,
+        dataset_format=dataset_format,
     )
     elapsed_time = time.time() - start_time
     print(
@@ -371,6 +567,7 @@ if __name__ == "__main__":
     chunk_len = float(sys.argv[9])
     overlap_len = float(sys.argv[10])
     normalization_mode = str(sys.argv[11])
+    dataset_format = str(sys.argv[12]) if len(sys.argv) > 12 else "wav"
     preprocess_training_set(
         input_root,
         sample_rate,
@@ -383,4 +580,5 @@ if __name__ == "__main__":
         chunk_len,
         overlap_len,
         normalization_mode,
+        dataset_format,
     )

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -125,7 +125,7 @@ try:
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
 except Exception as e:
-    print(f'Torch tf32: {e}')
+    print(f"Torch tf32: {e}")
 
 global_step = 0
 last_loss_gen_all = 0
@@ -178,8 +178,9 @@ def main():
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(randint(20000, 55555))
     # Check sample rate
-    wavs = glob.glob(
-        os.path.join(os.path.join(experiment_dir, "sliced_audios"), "*.wav")
+    sliced_dir = os.path.join(experiment_dir, "sliced_audios")
+    wavs = glob.glob(os.path.join(sliced_dir, "*.wav")) + glob.glob(
+        os.path.join(sliced_dir, "*.flac")
     )
     if wavs:
         _, sr = load_wav_to_torch(wavs[0])
@@ -189,7 +190,7 @@ def main():
             )
             os._exit(1)
     else:
-        print("No wav file found.")
+        print("No sliced audio file found.")
 
     if torch.cuda.is_available():
         device = torch.device("cuda")

--- a/rvc/train/utils.py
+++ b/rvc/train/utils.py
@@ -207,6 +207,33 @@ def load_wav_to_torch(full_path):
     return torch.FloatTensor(data), sample_rate
 
 
+# root of the installation, derived from this file rather than os.getcwd()
+APPLICATION_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+
+
+def resolve_dataset_path(path):
+    """
+    Resolves one filelist entry to a path that exists.
+
+    Filelists are now written relative to the application root, but older ones
+    hold absolute or working-directory-relative paths, so all three are
+    accepted. A path that resolves nowhere is returned untouched.
+
+    Args:
+        path (str): The path as written in the filelist.
+    """
+    if os.path.isabs(path):
+        return path
+    if os.path.exists(path):
+        return path
+    from_root = os.path.join(APPLICATION_ROOT, path)
+    if os.path.exists(from_root):
+        return from_root
+    return path
+
+
 def load_filepaths_and_text(filename, split="|"):
     """
     Load filepaths and associated text from a file.
@@ -216,7 +243,11 @@ def load_filepaths_and_text(filename, split="|"):
         split (str, optional): The delimiter used to split the lines.
     """
     with open(filename, encoding="utf-8") as f:
-        return [line.strip().split(split) for line in f]
+        rows = [line.strip().split(split) for line in f if line.strip()]
+    # every field but the trailing speaker id is a path
+    return [
+        [resolve_dataset_path(field) for field in row[:-1]] + row[-1:] for row in rows
+    ]
 
 
 class HParams:

--- a/tabs/train/train.py
+++ b/tabs/train/train.py
@@ -493,6 +493,17 @@ def train_tab():
                     visible=True,
                 )
 
+                dataset_format = gr.Radio(
+                    label=i18n("Sliced dataset format"),
+                    info=i18n(
+                        "Format the sliced dataset is written in. 'wav' is 32-bit float and lossless. 'flac' is also lossless but roughly half the size, stored as 24-bit PCM, so the rare slice that peaks above full scale is scaled down to fit."
+                    ),
+                    choices=["wav", "flac"],
+                    value="wav",
+                    interactive=True,
+                    visible=True,
+                )
+
                 noise_reduction = gr.Checkbox(
                     label=i18n("Noise Reduction"),
                     info=i18n(
@@ -537,6 +548,7 @@ def train_tab():
                     chunk_len,
                     overlap_len,
                     normalization_mode,
+                    dataset_format,
                 ],
                 outputs=[preprocess_output_info],
             )
@@ -586,6 +598,31 @@ def train_tab():
             value=True,
             interactive=True,
         )
+        with gr.Accordion(i18n("Advanced Settings"), open=False):
+            fp16_embeddings = gr.Checkbox(
+                label=i18n("Half-precision embedder"),
+                info=i18n(
+                    "Run the embedder forward pass in float16 on CUDA. Faster, and the features are still stored as float32. Ignored on CPU."
+                ),
+                value=False,
+                interactive=True,
+            )
+            compact_f0 = gr.Checkbox(
+                label=i18n("Compact pitch storage"),
+                info=i18n(
+                    "Store coarse pitch as uint8 instead of int64. The values are identical, the 'f0' folder is an eighth of the size, and training reads either format."
+                ),
+                value=False,
+                interactive=True,
+            )
+            remove_16k_slices = gr.Checkbox(
+                label=i18n("Delete 16 kHz slices after extraction"),
+                info=i18n(
+                    "Frees the disk space used by 'sliced_audios_16k', which is only needed to extract features. Re-extracting with a different pitch method or embedder afterwards requires preprocessing the dataset again."
+                ),
+                value=False,
+                interactive=True,
+            )
         with gr.Row(visible=False) as embedder_custom:
             with gr.Accordion(i18n("Custom Embedder"), open=True):
                 with gr.Row():
@@ -629,6 +666,9 @@ def train_tab():
                 embedder_model,
                 embedder_model_custom,
                 include_mutes,
+                remove_16k_slices,
+                compact_f0,
+                fp16_embeddings,
             ],
             outputs=[extract_output_info],
         )


### PR DESCRIPTION
Six defects in the preprocessing and feature extraction pipeline that fail
*silently*, four opt-in options for disk and speed, portable filelists, and a
fix for the conda environment inheriting the user's site-packages.

Everything that changes behaviour by default is a bug fix. Everything that
changes a format or a trade-off is opt-in and defaults to today's behaviour.

**Bug fixes (always on)**

- **Worker crashes were reported as success.** `run_pitch_extraction` and
  `run_embedding_extraction` called `concurrent.futures.wait(tasks)` and never
  read the futures, so an out-of-memory GPU or a missing model left extraction
  printing "completed" over a half-built `filelist.txt`. Now `as_completed` +
  `.result()`.
- **Three ways `_normalize_audio` could poison the dataset.** In `"pre"` mode a
  peak above 2.5 returned `None`, which became a `TypeError` reported as a
  generic "Error processing audio"; in `"post"` mode the same `None` could reach
  `wavfile.write`; and dividing by the peak without a zero check turned any
  silent file into a slice of `NaN` that propagates into the f0 and embedding
  features.
- **`simple_cut` discarded the tail of every file.** `if len(chunk) == chunk_length`
  dropped whatever did not fill a full window. The last window is now
  re-anchored to end on the final sample — real audio, no silence padding, at
  the cost of extra overlap.
- **`simple_cut` could fill the disk.** `overlap_len >= chunk_len` gave a
  non-positive stride and the loop wrote slices forever. Unreachable from the UI
  sliders, reachable from `core.py preprocess`.
- **Chunk lengths drifted.** `int(sr * seconds)` truncates, so a chunk and its
  overlap could disagree by a sample. `secs_to_samples` uses `Fraction` and
  validates once up front.
- **Speaker folders silently dropped a whole speaker.** `int(os.path.basename(root))`
  required a bare integer and the `except ValueError` wrapped the entire loop,
  so a folder named `0_maria` made every file under it vanish with only a
  printed note. Now
- **High-pass filter transient.** The DC-removal filter ran zero-state, reading
  a DC offset as a step and leaving a thump decaying over ~45 ms at the head of
  the first slice of every file. Now `sos` (at 48 Hz the poles sit at |p| = 0.998,
  where the transfer-function form is badly conditioned) primed from the mean of
  the opening 20 ms.
- **Smaller fixes.** `np.isfinite().all()` instead of `not np.isnan().any()`
  (`inf` used to reach the features and the retrieval index); files sorted
  longest-first so the strided split leaves each GPU a comparable total;
  embedding extraction serialised instead of fanned out over threads sharing one
  CUDA model.

**Portable filelists**

Filelists are now written relative to the application root with forward slashes,
derived from the module's own location rather than `os.getcwd()` (the extractor
runs as a subprocess). Old filelists keep working: `resolve_dataset_path`
accepts root-relative, absolute and CWD-relative entries, and only the new form
is produced.

| Delete 16 kHz slices | `--remove-16k-slices` | off |

FLAC support reaches beyond the preprocessor: `preparing_files` matches
artifacts by stem while preserving the real extension, extract globs both
formats, `train.py`'s sample-rate check sees both, and `data_utils` reads
compressed lengths from the header scaled to the same unit as WAV — the
`DistributedBucketSampler` boundaries are absolute and a slice outside them is
dropped from training entirely.

**Environment isolation**

`disable_user_site()` drops the per-user site-packages directory from `sys.path`
and exports `PYTHONNOUSERSITE=1`, which carries into the subprocesses spawned
for preprocessing, extraction and training. Called first thing in `app.py` and
`core.py`, and set in the six launcher scripts.

## Motivation and Context

Every bug above fails without an error. The pipeline reports success, training
starts, and the damage only shows up as a model that trains worse than it
should — or as an op

The high-pass fix is the one worth a number. Measured against the filter it
replaces, peak amplitude in the first 50 ms:

| signal | before | after |
|---|---|---|
| DC offset 0.05 | 0.049 | **0.000** |
| 85 Hz tone + DC | 0.526 | 0.526 |
| sine from zero | 1.093 | 1.110 |
| cosine from its peak | 1.042 | 1.050 |

Reviewers may wonder why the state is primed from the local mean rather than
from `audio[0]`, which is the obvious choice. Because `audio[0]` is *worse* than
zero-state: 1.403 on that last row. `sosfilt_zi` describes the state after a
constant input held
ImportError: safetensors>=0.8.0 is required ... but found safetensors==0.7.0
ImportError: Numba needs NumPy 2.3 or less. Got NumPy 2.4.

Both came from a user site holding `safetensors 0.7.0` / `numba 0.62.1` over the
env's correct `0.8.0` / `0.67.0`. Nothing in the user's own environment is
touched.

**Considered and rejected.** Matching filelist artifacts positionally with
`zip(strict=True)` (a regression against the current set intersection);
replacing the embedder loader (the current one supports six embedders);
FCPE test-time augmentation (large port for a secondary f0 method); ffmpeg as a
resampling backend (`soxr_vhq` is already better).

`Automatic` stays th

| scenario | Automatic | Simple 3.0/0.3 |
|---|---|---|
| edited speech | **4.6%** silent | 6.2% |
| 1.0 s pause every 4 s | **7.9%** silent | 24.1% |
| 2.5 s pause every 5 s | **6.1%** silent | 36.9% |

`Simple` also tested at 3.0/0.0 and 2.0/0.2; no variant beat `Automatic`.

## How has this been tested?

**Environment:** Windows 11, Python 3.12.14, torch 2.11.0+cu128, CUDA available.

The repository has no test suite, so verification was done with throwaway
harnesses plus real
  shorter than one chunk, tail below `MIN_TAIL_SECONDS`, exact fit), checking
  slice count and that the re-anchored tail is full length.
- The stride guard for `overlap_len >= chunk_len`.
- Speaker-folder validation: both the non-contiguous-ID and the un-numbered
  folder rejection paths, asserting exit code and message.
- The `"pre"` skip path, asserting the file is named in the output, that no
  generic "Error processing audio" appears, and that every written slice is
  finite — this is the regression test for the `NaN` bug.
- Filelist generation in both dataset formats: row count, forward slashes, no
  CWD-relative entries, mute rows relative to the root.
- Legacy filelist resolution (absolute and root-relative entries) read from a
  working directory that is *not* the repository root.
- `uint8` vs `int64` coarse pitch: bit-identical values across the full
  50–1100 Hz range, 840 B → 105 B.
- `discard_16k_slice
  `mute*` folders, removes otherwise.
- WAV/FLAC bucket-length parity in `data_utils._slice_length` — the same slice
  in both formats yields length 344.

*End to end, through the real CLI:*

- `core.py preprocess` → `core.py extract` on a two-speaker dataset with
  `--dataset-format flac --compact-f0 --remove-16k-slices` on CPU. Verified the
  filelist is root-relative with forward slashes, `f0/` is `uint8`, `extracted/`
  is `float32`, and `sliced_audios_16k/` is gone.
- The same pipeline on `cuda:0` with `--fp16-embeddings --compact-f0`, verifying
  the stored features are still finite `float32` (149, 768).
- The resulting FLAC dataset loaded through `TextAudioLoaderMultiNSFsid` from a
  different working directory: 18 items, bucket lengths inside the sampler
  boundaries, `phone
## Screenshots (if appropriate):

N/A — the UI changes are one new radio (sliced dataset format) in the existing
Preprocess → Advanced Settings accordion, and a new Advanced Settings accordion
in the Extract section holding three checkboxes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The breaking box is checked for one thing, and I would rather flag it than have
a reviewer find it: **speaker ID validation is now fatal.** A dataset whose
folders are not contiguous integers from 0 previously kept going and produced
slices; it now exits with an explanatory message. Nothing that worked before
stops working — a gap in the numbering sized the speaker embedding wrong and
turned into an assert during training, and an un-numbered folder had its files
silently dropped — but the *failure mode* moves from "produces a broken model"
to "refuses at preprocess time". Anyone with such a dataset will see a new stop.

Two behaviour changes that are not API breaks but do alter output, worth naming:
`simple_cut` now emits more slices per file (the recovered tails), and
preprocessed datasets get root-relative filelists. Reading old filelists is
fully backwards compatible.

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Notes on the unchecked boxes:

- **Documentation.** The repository has no `docs/` directory and the README does

Two behaviour changes that are not API breaks but do alter output, worth naming:
`simple_cut` now emits more slices per file (the recovered tails), and
preprocessed datasets get root-relative filelists. Reading old filelists is
fully backwards compatible.

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.