### PR TITLE
Fix FAISS index retrieval: nprobe=1, NaN weights on exact matches, and clustering that shrinks larger datasets

### DIFF
--- a/rvc/infer/pipeline.py
+++ b/rvc/infer/pipeline.py
@@ -21,6 +21,13 @@ logging.getLogger("faiss").setLevel(logging.WARNING)
 FILTER_ORDER = 5
 CUTOFF_FREQUENCY = 48  # Hz
 SAMPLE_RATE = 16000  # Hz
+# Minimum IVF cells a retrieval search visits. Indexes store their own nprobe,
+# and every index built before it was tuned stored 1, which searches a single
+# cell out of thousands. Matches the realtime pipeline's default.
+MIN_INDEX_NPROBE = 12
+# Distances below this are treated as this. An exact match scores zero, and the
+# 1/distance weighting below turns that into NaN for the whole frame.
+MIN_INDEX_DISTANCE = 1e-8
 bh, ah = signal.butter(
     N=FILTER_ORDER, Wn=CUTOFF_FREQUENCY, btype="high", fs=SAMPLE_RATE
 )
@@ -377,7 +384,7 @@ class Pipeline:
     def _retrieve_speaker_embeddings(self, feats, index, big_npy, index_rate):
         npy = feats[0].cpu().numpy()
         score, ix = index.search(npy, k=8)
-        weight = np.square(1 / score)
+        weight = np.square(1 / np.maximum(score, MIN_INDEX_DISTANCE))
         weight /= weight.sum(axis=1, keepdims=True)
         npy = np.sum(big_npy[ix] * np.expand_dims(weight, axis=2), axis=1)
         feats = (
@@ -429,6 +436,16 @@ class Pipeline:
         if file_index != "" and os.path.exists(file_index) and index_rate > 0:
             try:
                 index = faiss.read_index(file_index)
+                try:
+                    # Lift an index off the nprobe it was written with, without
+                    # lowering one that was tuned higher. Guarded separately so
+                    # an index with no IVF structure still loads and searches.
+                    index_ivf = faiss.extract_index_ivf(index)
+                    index_ivf.nprobe = max(
+                        index_ivf.nprobe, min(MIN_INDEX_NPROBE, index_ivf.nlist)
+                    )
+                except RuntimeError:
+                    pass
                 big_npy = index.reconstruct_n(0, index.ntotal)
             except Exception as error:
                 print(f"An error occurred reading the FAISS index: {error}")

--- a/rvc/realtime/utils/torch.py
+++ b/rvc/realtime/utils/torch.py
@@ -278,6 +278,11 @@ class IndexWrapper:
                 score, ix = self.index.search(npy, k)
 
                 return (
-                    torch.from_numpy(score).to(self.device).to(self.dtype),
+                    # Same clamp as the GPU branch above: an exact match scores
+                    # zero, and the caller weights by 1/distance.
+                    torch.from_numpy(score)
+                    .to(self.device)
+                    .to(self.dtype)
+                    .clamp(min=self.clamp),
                     torch.from_numpy(ix).to(self.device).long(),
                 )

--- a/rvc/train/process/extract_index.py
+++ b/rvc/train/process/extract_index.py
@@ -6,6 +6,177 @@ import faiss
 import numpy as np
 from sklearn.cluster import MiniBatchKMeans
 
+# Fixed so the same dataset always produces the same index.
+SEED = 1234
+
+# Upper bound on the vectors an index keeps. Inference reconstructs all of them
+# (768 dims, float32 -> 293 MB at 100k), so this is the retrieval's memory cost
+# as much as its fidelity. 200k is what the previous size test already allowed
+# through untouched, so nothing built today gets larger than it could before.
+MAX_INDEX_VECTORS = int(os.environ.get("APPLIO_INDEX_MAX_VECTORS", 200_000))
+
+# Cluster count for the explicit "KMeans" algorithm, clamped to the frames
+# available: MiniBatchKMeans raises outright when asked for more clusters than
+# it has samples.
+KMEANS_CLUSTERS = 10_000
+
+# How many IVF cells a search visits. This is stored inside the .index file, so
+# the value chosen here is the one every future search uses. It was 1, which
+# means a search looked in a single cell out of thousands and returned whatever
+# it found there as the "nearest" neighbours.
+NPROBE_LADDER = (1, 2, 4, 8, 16, 32, 64)
+NPROBE_TARGET_RECALL = 0.95
+RECALL_QUERIES = 128
+RECALL_K = 8
+
+
+def load_features(feature_dir):
+    """
+    Load every extracted feature file into one array.
+
+    Args:
+        feature_dir (str): Directory holding the extracted .npy features.
+    """
+    npys = []
+    dropped = 0
+    for name in sorted(os.listdir(feature_dir)):
+        if not name.endswith(".npy"):
+            continue
+        phone = np.load(os.path.join(feature_dir, name))
+        if phone.ndim != 2 or phone.shape[0] == 0:
+            print(f"Skipping {name}: unexpected shape {phone.shape}.")
+            continue
+        # A NaN vector matches nothing and poisons the k-means fit; extraction
+        # already skips files it detects, but an index is cheap to protect.
+        finite = np.isfinite(phone).all(axis=1)
+        dropped += int((~finite).sum())
+        if finite.any():
+            npys.append(np.asarray(phone[finite], dtype=np.float32))
+
+    if dropped:
+        print(f"Dropped {dropped} non-finite frames.")
+    if not npys:
+        return None
+    return np.ascontiguousarray(np.concatenate(npys, axis=0))
+
+
+def reduce_features(big_npy, index_algorithm, rng):
+    """
+    Bring the vector count under the cap, or apply the requested clustering.
+
+    Args:
+        big_npy (np.ndarray): All extracted feature frames.
+        index_algorithm (str): "Auto", "Faiss" or "KMeans".
+        rng (np.random.Generator): Seeded generator, for a reproducible index.
+    """
+    total = big_npy.shape[0]
+
+    if index_algorithm == "KMeans":
+        # Clamped because MiniBatchKMeans raises when n_clusters exceeds
+        # n_samples, which made this option unusable on a small dataset.
+        clusters = min(KMEANS_CLUSTERS, total)
+        print(f"Running KMeans: {total} vectors -> {clusters} centroids...")
+        return np.ascontiguousarray(
+            MiniBatchKMeans(
+                n_clusters=clusters,
+                verbose=True,
+                batch_size=256 * cpu_count(),
+                compute_labels=False,
+                init="random",
+                random_state=SEED,
+            )
+            .fit(big_npy)
+            .cluster_centers_,
+            dtype=np.float32,
+        )
+
+    if index_algorithm == "Faiss" or total <= MAX_INDEX_VECTORS:
+        return big_npy
+
+    # Over the cap on the automatic path. Keeping a random sample of real
+    # frames rather than collapsing to a few thousand centroids: the retrieval
+    # pulls a query toward something the speaker actually produced, and a
+    # centroid is an average that no longer is. Clustering also used to make a
+    # larger dataset produce a *smaller* index than a smaller one.
+    print(f"Keeping a random {MAX_INDEX_VECTORS} of {total} vectors...")
+    keep = np.sort(rng.choice(total, size=MAX_INDEX_VECTORS, replace=False))
+    return np.ascontiguousarray(big_npy[keep])
+
+
+def measure_recall(index, big_npy, rng, nprobe_values):
+    """
+    Top-k recall of the IVF search against an exact one, per nprobe value.
+
+    An index that searches a single cell still loads, still returns results and
+    still looks like it works; the neighbours it returns are simply not the
+    nearest. Measuring is the only way that surfaces.
+
+    Args:
+        index (faiss.Index): The trained index.
+        big_npy (np.ndarray): The vectors it was built from.
+        rng (np.random.Generator): Seeded generator.
+        nprobe_values (list of int): Values to measure, in order.
+    """
+    count = big_npy.shape[0]
+    if count <= RECALL_K:
+        return {}
+
+    sample = rng.choice(count, size=min(RECALL_QUERIES, count), replace=False)
+    probe = np.ascontiguousarray(big_npy[sample])
+
+    # The exact answer does not depend on nprobe, so it is computed once.
+    norms = (big_npy**2).sum(axis=1)
+    exact = np.empty((probe.shape[0], RECALL_K), dtype=np.int64)
+    for start in range(0, probe.shape[0], 32):
+        block = probe[start : start + 32]
+        scores = norms[None, :] - 2.0 * (block @ big_npy.T)
+        exact[start : start + 32] = np.argpartition(scores, RECALL_K, axis=1)[
+            :, :RECALL_K
+        ]
+
+    index_ivf = faiss.extract_index_ivf(index)
+    recalls = {}
+    for nprobe in nprobe_values:
+        index_ivf.nprobe = nprobe
+        _, approximate = index.search(probe, RECALL_K)
+        recalls[nprobe] = float(
+            np.mean(
+                [len(set(a) & set(b)) / RECALL_K for a, b in zip(approximate, exact)]
+            )
+        )
+    return recalls
+
+
+def tune_nprobe(index, big_npy, rng):
+    """
+    Raise nprobe until the search finds the neighbours it claims to.
+
+    The value is stored inside the .index file, so this runs once here rather
+    than being guessed at every search.
+
+    Args:
+        index (faiss.Index): The trained index.
+        big_npy (np.ndarray): The vectors it was built from.
+        rng (np.random.Generator): Seeded generator.
+    """
+    index_ivf = faiss.extract_index_ivf(index)
+    ladder = sorted({min(int(index_ivf.nlist), value) for value in NPROBE_LADDER})
+
+    recalls = measure_recall(index, big_npy, rng, ladder)
+    if not recalls:
+        index_ivf.nprobe = ladder[-1]
+        return index_ivf.nprobe, None
+
+    for nprobe in ladder:
+        if recalls[nprobe] >= NPROBE_TARGET_RECALL:
+            index_ivf.nprobe = nprobe
+            return nprobe, recalls[nprobe]
+
+    best = max(recalls, key=recalls.get)
+    index_ivf.nprobe = best
+    return best, recalls[best]
+
+
 # Parse command line arguments
 exp_dir = str(sys.argv[1])
 index_algorithm = str(sys.argv[2])
@@ -22,54 +193,43 @@ if not os.path.exists(feature_dir):
 index_filename_added = f"{model_name}.index"
 index_filepath_added = os.path.join(exp_dir, index_filename_added)
 
+# Regenerating used to be a silent no-op, so changing the algorithm and running
+# again quietly handed back the previous index.
 if os.path.exists(index_filepath_added):
-    pass
-else:
-    npys = []
-    print(f"Generating index for '{model_name}', this may take a while...")
-    listdir_res = sorted(os.listdir(feature_dir))
+    print(f"Replacing the existing index at '{index_filepath_added}'.")
 
-    for name in listdir_res:
-        file_path = os.path.join(feature_dir, name)
-        phone = np.load(file_path)
-        npys.append(phone)
+print(f"Generating index for '{model_name}', this may take a while...")
+big_npy = load_features(feature_dir)
 
-    if not npys:
-        print(
-            f"Feature files in {feature_dir} could not be loaded correctly. Did you run preprocessing and feature extraction steps?"
-        )
-        sys.exit(1)
+if big_npy is None:
+    print(
+        f"Feature files in {feature_dir} could not be loaded correctly. Did you run preprocessing and feature extraction steps?"
+    )
+    sys.exit(1)
 
-    big_npy = np.concatenate(npys, axis=0)
+rng = np.random.default_rng(SEED)
+big_npy = reduce_features(big_npy, index_algorithm, rng)
 
-    big_npy_idx = np.arange(big_npy.shape[0])
-    np.random.shuffle(big_npy_idx)
-    big_npy = big_npy[big_npy_idx]
+n_ivf = max(1, min(int(16 * np.sqrt(big_npy.shape[0])), big_npy.shape[0] // 39))
 
-    if big_npy.shape[0] > 2e5 or index_algorithm == "KMeans":
-        big_npy = (
-            MiniBatchKMeans(
-                n_clusters=10000,
-                verbose=True,
-                batch_size=256 * cpu_count(),
-                compute_labels=False,
-                init="random",
-            )
-            .fit(big_npy)
-            .cluster_centers_
-        )
+# index_added
+index_added = faiss.index_factory(768, f"IVF{n_ivf},Flat")
+index_added.train(big_npy)
 
-    n_ivf = min(int(16 * np.sqrt(big_npy.shape[0])), big_npy.shape[0] // 39)
+batch_size_add = 8192
+for i in range(0, big_npy.shape[0], batch_size_add):
+    index_added.add(big_npy[i : i + batch_size_add])
 
-    # index_added
-    index_added = faiss.index_factory(768, f"IVF{n_ivf},Flat")
-    index_ivf_added = faiss.extract_index_ivf(index_added)
-    index_ivf_added.nprobe = 1
-    index_added.train(big_npy)
+nprobe, recall = tune_nprobe(index_added, big_npy, rng)
 
-    batch_size_add = 8192
-    for i in range(0, big_npy.shape[0], batch_size_add):
-        index_added.add(big_npy[i : i + batch_size_add])
-
-    faiss.write_index(index_added, index_filepath_added)
-    print(f"Saved index file '{index_filepath_added}'")
+faiss.write_index(index_added, index_filepath_added)
+print(
+    f"Index: {big_npy.shape[0]} vectors, IVF{n_ivf}, nprobe {nprobe}"
+    + (f", top-{RECALL_K} recall {recall:.1%}" if recall is not None else "")
+)
+if recall is not None and recall < NPROBE_TARGET_RECALL:
+    print(
+        "Recall stays low at the highest nprobe tried; searches will return "
+        "some neighbours that are not the nearest."
+    )
+print(f"Saved index file '{index_filepath_added}'")


### PR DESCRIPTION
## Description

Four defects in index generation and retrieval, all of which fail quietly — the
index builds, loads and searches, and simply does not return what it claims to.

**1. Every index Applio has ever built searches a single IVF cell.**
`extract_index.py` set `index_ivf_added.nprobe = 1` before writing. `nprobe` is
persisted inside the `.index` file, so this is not a build-time detail: it is
the value every future search uses. Measured against an exact search on real
ContentVec features, top-8 recall is **69.0%** at `nprobe=1` — nearly a third of
the "nearest neighbours" are not near — against 97.4% at 8 and 99.5% at 16.

Fixed on both sides:
- `rvc/infer/pipeline.py` raises `nprobe` when it loads an index, with
  `max(stored, 12)`. This fixes **every index that already exists**, including
  third-party ones downloaded through Applio, without lowering one that was
  tuned higher.
- `extract_index.py` now measures top-8 recall against an exact search and
  climbs `1→2→4→8→16→32→64` until it reaches 95%, storing the result.

**2. An exact match produces NaN for the whole frame.** `pipeline.py` weighted
neighbours with `np.square(1 / score)`. A query identical to an indexed vector
scores exactly `0.0`, so the weight is `inf`, the normalisation is `inf/inf`,
and `NaN` flows into the generator. Reproduced: 16 NaN weights out of 128. This
fires precisely when someone tests their model on audio that was in its own
training set.

**3. Clustering inverted the relationship between dataset size and index
quality.** `if big_npy.shape[0] > 2e5 ... n_clusters=10000` meant 199k vectors
kept all 199k, while 201k collapsed to 10k centroids — a larger dataset produced
an index 20× smaller. The automatic path now subsamples real frames to a cap
instead. Centroids are averages of frames rather than frames, and retrieval
exists to pull a query toward something the speaker actually produced.

**4. `KMeans` crashed on small datasets.** `n_clusters=10000` was fixed, so
choosing that algorithm with fewer than 10 000 extracted frames raised
`ValueError: n_samples=500 should be >= n_clusters=10000`. Now clamped to the
frames available.

Also in this diff, all minor:
- Regenerating an index was a silent no-op (`if os.path.exists(...): pass`), so
  changing the algorithm and running again handed back the previous index.
- `np.random.shuffle` ran unseeded, so the same dataset produced a different
  index each time. Now seeded.
- Non-finite feature frames are dropped before the index is built.
- `rvc/realtime/utils/torch.py` clamps the distance on its GPU path but not on
  its FAISS CPU fallback — same NaN, same fix.

## Motivation and Context

The `nprobe` and clamp values here are not imported from anywhere: Applio's own
realtime module already uses exactly them (`nprobe: int = 12`,
`clamp: float = 1e-8` in `rvc/realtime/utils/torch.py`). The offline inference
path simply never got the same treatment. This PR mostly brings it into line
with code already in the repository.

What the index is *for* is finding the closest thing the target speaker actually
said, so I measured that rather than measuring the search against itself. Using
the same `1/d²` blend the pipeline feeds the generator, mean distance from a
query to the blended result:

| index | vectors | nprobe | blended distance | excess over ideal |
|---|---|---|---|---|
| ideal (exact search, all frames) | 278,720 | — | 4.347 | — |
| old (10k centroids, nprobe=1) | 10,000 | 1 | 4.557 | **4.8%** |
| new (200k frames, tuned nprobe) | 200,000 | 4 | 4.362 | **0.4%** |

Worth reading the middle row carefully: the old index's *top-1* distance is
lower than the ideal's (4.442 vs 5.058), because a centroid is an average and an
average sits close to everything. That is the argument against clustering here
in one number — it looks like a better match while being a thing nobody said.

Cost of the fix, measured on a 120k-vector index searching 50 frames (one second
of audio): 2.60 ms at `nprobe=1`, 4.21 ms at 8, 5.43 ms at 16. Index build time
on a 278k-frame dataset is comparable to before — 54 s against 49 s, since the
recall measurement costs a few seconds but k-means is no longer run.

**Where the vector cap comes from.** `MAX_INDEX_VECTORS` is 200,000, which is
exactly what the previous size test already let through untouched, so the
ceiling on index size is unchanged. It is overridable with
`APPLIO_INDEX_MAX_VECTORS`. See the breaking-change note below for who this
affects; if maintainers would rather trade some quality for half the memory,
100,000 is a reasonable alternative default and a one-line change.

## How has this been tested?

**Environment:** Windows 11, Python 3.12.14, faiss-cpu, torch 2.11.0+cu128.

There is no test suite in the repository, so this was verified with measurement
scripts and real index builds.

*Reproducing the defects on this branch's base (`upstream/main` @ `0724dd77`),
before fixing them:*
- Top-8 recall of `nprobe=1` against an exact search, on genuine ContentVec
  features extracted from `logs/reference/reference.wav`: 69.0%.
- `np.square(1 / score)` on a query identical to an indexed vector: 16 NaN
  weights out of 128.
- `MiniBatchKMeans(n_clusters=10000)` on 500 samples: `ValueError`.
- `nprobe` read back from a written `.index` file: 1, and settable at load time
  — which is what makes the retroactive fix possible.

*After:*
- Small dataset (1,742 real frames): tunes to `nprobe=8`, recall 98.4%.
- Large dataset (278,720 frames, over the cap): subsamples to 200,000,
  `nprobe=4`, recall 98.3%, 54 s.
- `KMeans` on the small dataset: completes instead of raising.
- Regenerating over an existing index: prints that it is replacing it, and does.
- A legacy index written with `nprobe=1`: lifted to 12 by the pipeline's load
  path.
- `_retrieve_speaker_embeddings` on queries identical to indexed vectors:
  finite output, 0 NaN, where the old code produced 16.
- A third-party `IndexFlatL2` with no IVF structure: still loads and searches.
  The `extract_index_ivf` call is in its own `try` for this reason — without it,
  a non-IVF index would fall into the outer handler and disable retrieval
  entirely, which would have been a regression introduced by this PR.
- `app.py` imports and builds the UI. `black` clean.

*Not covered:* no listening test. The A/B table above is computed on a 278k-frame
set built by replicating 1,742 real frames with noise, because the only speech
in the repository is a 35-second clip. The mechanism and the direction are
clear, but the magnitude on a real, diverse dataset may differ. The 69% recall
figure is the one measured on genuinely real frames and the one I would stand
behind.

## Screenshots (if appropriate):

N/A — no UI changes. Index generation prints one extra summary line:

```
Index: 200000 vectors, IVF5128, nprobe 4, top-8 recall 98.3%
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I would rather flag this than have it found in review. **Newly built indexes for
datasets over ~66 minutes get much larger.** A dataset above 200,000 extracted
frames previously collapsed to 10,000 centroids — a 29 MB index — and now keeps
200,000 real vectors, which is 586 MB (`200000 × 768 × 4`). Inference calls
`reconstruct_n(0, ntotal)`, so that is resident RAM, and VRAM on the realtime
path.

Three things bound the impact: the ceiling itself is unchanged, since any
dataset between 66 minutes and the old 200k threshold already produced an index
of that size; existing `.index` files are untouched, because nothing regenerates
them until the user asks; and `APPLIO_INDEX_MAX_VECTORS` lowers it for anyone
who needs that.

The `nprobe` lift *does* apply to existing indexes immediately, by design — that
is the point of doing it at load time. It costs a few milliseconds per second of
audio and changes retrieval output, for the better, on every existing model.

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.