### PR TITLE
fix(refinegan): eliminate unvoiced noise hallucination during rests in SineGenerator

### DIFF
--- a/rvc/lib/algorithm/generators/refinegan.py
+++ b/rvc/lib/algorithm/generators/refinegan.py
@@ -256,7 +256,7 @@ class SineGenerator(nn.Module):
 
             uv = self._f02uv(f0)
 
-            noise_amp = uv * self.noise_std + (1 - uv) * self.sine_amp / 3
+            noise_amp = uv * self.noise_std
             noise = noise_amp * torch.randn_like(sine_waves)
 
             sine_waves = sine_waves * uv + noise


### PR DESCRIPTION
## Description
In `RefineGANGenerator`'s `SineGenerator` (`rvc/lib/algorithm/generators/refinegan.py`), unvoiced frames were assigned an unvoiced noise amplitude:
```python
noise_amp = uv * self.noise_std + (1 - uv) * self.sine_amp / 3
```

When an audio segment contains a musical rest, speech pause, or silence ($\text{F0} = 0$, $\text{uv} = 0$), this injects $\approx 33.3\%$ amplitude Gaussian noise directly into the source excitation. When convolved through the 4-stage multi-scale downsamplers and `ParallelResBlocks`, the generator synthesizes an audible static / breath hiss during pure silence.

## Solution
Change `noise_amp` to only apply micro-noise during voiced frames:
```python
noise_amp = uv * self.noise_std
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.

## Verification
- **Voiced notes ($\text{uv} = 1$):** 100% full harmonic richness, micro-noise, and acoustic texture are preserved.
- **Unvoiced rests ($\text{uv} = 0$):** Excitation drops to true digital silence ($0.000$ energy) with zero breath/static hallucination.
- Tested across sample rates (24k, 32k, 44.1k, 48k) and end-to-end `Synthesizer.infer` pipeline.
- Requires zero retraining for existing `.pth` models.

## Feature Request for Maintainers
Could the team consider releasing **48kHz base pretrained checkpoints** for RefineGAN in `Resources/refinegan/`? 48kHz would allow RefineGAN to match HiFi-GAN's full 24kHz audio bandwidth for high-fidelity studio mastering.
