### PR TITLE
refactor(discriminator): enhance forward method with no_grad_real option

### DIFF
--- a/rvc/lib/algorithm/discriminators.py
+++ b/rvc/lib/algorithm/discriminators.py
@@ -49,15 +49,40 @@ class MultiPeriodDiscriminator(torch.nn.Module):
             ]
         )
 
-    def forward(self, y, y_hat):
+    def forward(self, y, y_hat, no_grad_real: bool = False):
+        """``no_grad_real`` runs the real branch under ``no_grad``.
+
+        The generator update needs the real side only as a *target*: its logits
+        are thrown away and its feature maps are the constant the feature
+        matching loss measures against.  Left differentiable it still builds a
+        full activation graph, and the feature loss then backwards through it
+        into discriminator weights whose gradients are zeroed before they are
+        ever stepped -- the generator update runs after the discriminator's,
+        and ``optim_d.zero_grad`` brackets it on both sides.  So the whole real
+        backward is work with no consumer.
+
+        Off by default because the discriminator update *does* need it: that is
+        the pass whose gradient trains ``net_d``.
+        """
         y_d_rs, y_d_gs, fmap_rs, fmap_gs = [], [], [], []
+        checkpointing = self.training and self.checkpointing
         for d in self.discriminators:
-            if self.training and self.checkpointing:
+            # The other two arms add no context manager at all, and not
+            # ``enable_grad``: an outer ``no_grad`` (the validation path) must
+            # stay in force.
+            if no_grad_real:
+                with torch.no_grad():
+                    y_d_r, fmap_r = d(y)
+            elif checkpointing:
                 y_d_r, fmap_r = checkpoint(d, y, use_reentrant=False)
-                y_d_g, fmap_g = checkpoint(d, y_hat, use_reentrant=False)
             else:
                 y_d_r, fmap_r = d(y)
+
+            if checkpointing:
+                y_d_g, fmap_g = checkpoint(d, y_hat, use_reentrant=False)
+            else:
                 y_d_g, fmap_g = d(y_hat)
+
             y_d_rs.append(y_d_r)
             y_d_gs.append(y_d_g)
             fmap_rs.append(fmap_r)

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -708,8 +708,11 @@ def train_and_evaluate(
             # skips the weight-gradient half of the discriminator backward
             # while the gradient that *is* wanted, the one flowing back into
             # ``y_hat``, is unchanged.  Paired with ``no_grad_real`` below.
-            discriminator_model = net_d.module if hasattr(net_d, "module") else net_d
-            for parameter in discriminator_model.parameters():
+            # ``net_d`` and not the unwrapped module: DDP holds the module as
+            # a submodule and adds no parameters of its own, so this is the
+            # same tensors either way.  The unwrap below is for the *call*,
+            # which is a different question.
+            for parameter in net_d.parameters():
                 parameter.requires_grad_(False)
             try:
                 with torch.amp.autocast(
@@ -722,10 +725,18 @@ def train_and_evaluate(
                     # it builds a graph nothing consumes.  See
                     # ``MultiPeriodDiscriminator.forward``.
                     #
-                    # The unwrapped module, not ``net_d``: under DDP the
-                    # wrapper's forward arms the reducer for a backward that
-                    # will never produce a discriminator gradient, and no
-                    # gradient sync is wanted here in the first place.
+                    # The unwrapped module, and here the unwrap is load
+                    # bearing: ``DistributedDataParallel._post_forward`` calls
+                    # ``reducer.prepare_for_backward`` whenever grad is
+                    # enabled, arming an allreduce that this backward can never
+                    # complete -- every parameter is frozen, so no gradient
+                    # hook fires.  The next iteration's discriminator forward
+                    # then raises "Expected to have finished reduction in the
+                    # prior iteration before starting a new one".  No gradient
+                    # sync is wanted here in the first place.
+                    discriminator_model = (
+                        net_d.module if hasattr(net_d, "module") else net_d
+                    )
                     _, y_d_hat_g, fmap_r, fmap_g = discriminator_model(
                         wave, y_hat, no_grad_real=True
                     )
@@ -788,7 +799,7 @@ def train_and_evaluate(
                 # a captured state would restore a constant.  A freeze added
                 # anywhere else -- a frozen-D stage, a partial pretrained load
                 # -- makes that false, and this is the line to change.
-                for parameter in discriminator_model.parameters():
+                for parameter in net_d.parameters():
                     parameter.requires_grad_(True)
 
             global_step += 1

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -708,99 +708,96 @@ def train_and_evaluate(
             # skips the weight-gradient half of the discriminator backward
             # while the gradient that *is* wanted, the one flowing back into
             # ``y_hat``, is unchanged.  Paired with ``no_grad_real`` below.
-            # ``net_d`` and not the unwrapped module: DDP holds the module as
-            # a submodule and adds no parameters of its own, so this is the
-            # same tensors either way.  The unwrap below is for the *call*,
-            # which is a different question.
-            for parameter in net_d.parameters():
-                parameter.requires_grad_(False)
-            try:
-                with torch.amp.autocast(
-                    device_type="cuda", enabled=use_amp, dtype=train_dtype
-                ):
-                    # Generator backward and update.
-                    #
-                    # ``no_grad_real``: the real side is the feature matching
-                    # *target* and its logits are discarded, so differentiating
-                    # it builds a graph nothing consumes.  See
-                    # ``MultiPeriodDiscriminator.forward``.
-                    #
-                    # The unwrapped module, and here the unwrap is load
-                    # bearing: ``DistributedDataParallel._post_forward`` calls
-                    # ``reducer.prepare_for_backward`` whenever grad is
-                    # enabled, arming an allreduce that this backward can never
-                    # complete -- every parameter is frozen, so no gradient
-                    # hook fires.  The next iteration's discriminator forward
-                    # then raises "Expected to have finished reduction in the
-                    # prior iteration before starting a new one".  No gradient
-                    # sync is wanted here in the first place.
-                    discriminator_model = (
-                        net_d.module if hasattr(net_d, "module") else net_d
-                    )
-                    _, y_d_hat_g, fmap_r, fmap_g = discriminator_model(
-                        wave, y_hat, no_grad_real=True
-                    )
+            # ``Module.requires_grad_`` *is* the loop over ``parameters()``,
+            # and on ``net_d`` and not the unwrapped module because DDP holds
+            # the module as a submodule and adds no parameters of its own --
+            # the same tensors either way.  The unwrap below is for the
+            # *call*, which is a different question.
+            net_d.requires_grad_(False)
+            with torch.amp.autocast(
+                device_type="cuda", enabled=use_amp, dtype=train_dtype
+            ):
+                # Generator backward and update.
+                #
+                # ``no_grad_real``: the real side is the feature matching
+                # *target* and its logits are discarded, so differentiating
+                # it builds a graph nothing consumes.  See
+                # ``MultiPeriodDiscriminator.forward``.
+                #
+                # The unwrapped module, and here the unwrap is load
+                # bearing: ``DistributedDataParallel._post_forward`` calls
+                # ``reducer.prepare_for_backward`` whenever grad is
+                # enabled, arming an allreduce that this backward can never
+                # complete -- every parameter is frozen, so no gradient
+                # hook fires.  The next iteration's discriminator forward
+                # then raises "Expected to have finished reduction in the
+                # prior iteration before starting a new one".  No gradient
+                # sync is wanted here in the first place.
+                discriminator_model = (
+                    net_d.module if hasattr(net_d, "module") else net_d
+                )
+                _, y_d_hat_g, fmap_r, fmap_g = discriminator_model(
+                    wave, y_hat, no_grad_real=True
+                )
 
-                if multiscale_mel_loss:
-                    loss_mel = fn_mel_loss(wave, y_hat) * config.train.c_mel / 3.0
-                else:
-                    wave_mel = mel_spectrogram_torch(
-                        wave.float().squeeze(1),
-                        config.data.filter_length,
-                        config.data.n_mel_channels,
-                        config.data.sample_rate,
-                        config.data.hop_length,
-                        config.data.win_length,
-                        config.data.mel_fmin,
-                        config.data.mel_fmax,
-                    )
-                    y_hat_mel = mel_spectrogram_torch(
-                        y_hat.float().squeeze(1),
-                        config.data.filter_length,
-                        config.data.n_mel_channels,
-                        config.data.sample_rate,
-                        config.data.hop_length,
-                        config.data.win_length,
-                        config.data.mel_fmin,
-                        config.data.mel_fmax,
-                    )
-                    loss_mel = fn_mel_loss(wave_mel, y_hat_mel) * config.train.c_mel
-                loss_kl = kl_loss(z_p, logs_q, m_p, logs_p, z_mask) * config.train.c_kl
-                loss_fm = feature_loss(fmap_r, fmap_g)
-                loss_gen, _ = generator_loss(y_d_hat_g)
-                loss_gen_all = loss_gen + loss_fm + loss_mel + loss_kl
+            if multiscale_mel_loss:
+                loss_mel = fn_mel_loss(wave, y_hat) * config.train.c_mel / 3.0
+            else:
+                wave_mel = mel_spectrogram_torch(
+                    wave.float().squeeze(1),
+                    config.data.filter_length,
+                    config.data.n_mel_channels,
+                    config.data.sample_rate,
+                    config.data.hop_length,
+                    config.data.win_length,
+                    config.data.mel_fmin,
+                    config.data.mel_fmax,
+                )
+                y_hat_mel = mel_spectrogram_torch(
+                    y_hat.float().squeeze(1),
+                    config.data.filter_length,
+                    config.data.n_mel_channels,
+                    config.data.sample_rate,
+                    config.data.hop_length,
+                    config.data.win_length,
+                    config.data.mel_fmin,
+                    config.data.mel_fmax,
+                )
+                loss_mel = fn_mel_loss(wave_mel, y_hat_mel) * config.train.c_mel
+            loss_kl = kl_loss(z_p, logs_q, m_p, logs_p, z_mask) * config.train.c_kl
+            loss_fm = feature_loss(fmap_r, fmap_g)
+            loss_gen, _ = generator_loss(y_d_hat_g)
+            loss_gen_all = loss_gen + loss_fm + loss_mel + loss_kl
 
-                if loss_gen_all < lowest_value["value"]:
-                    lowest_value = {
-                        "step": global_step,
-                        "value": loss_gen_all,
-                        "epoch": epoch,
-                    }
-                optim_g.zero_grad()
-                if train_dtype == torch.float16:
-                    scaler.scale(loss_gen_all).backward()
-                    scaler.unscale_(optim_g)
-                    grad_norm_g = commons.grad_norm(net_g.parameters())
-                    scaler.step(optim_g)
-                    scaler.update()
-                else:
-                    loss_gen_all.backward()
-                    grad_norm_g = commons.grad_norm(net_g.parameters())
-                    optim_g.step()
-            finally:
-                # ``finally`` and not a plain restore after the step: a raise
-                # anywhere above would otherwise leave every ``net_d``
-                # parameter frozen for the rest of the run, with ``loss_disc``
-                # still logged and ``optim_d.step`` still called -- a
-                # discriminator that has silently stopped learning.
-                # Unconditionally ``True`` and not a saved state list: these
-                # four lines are the only ``requires_grad`` in the codebase, so
-                # every discriminator parameter is trainable at every step and
-                # a captured state would restore a constant.  A freeze added
-                # anywhere else -- a frozen-D stage, a partial pretrained load
-                # -- makes that false, and this is the line to change.
-                for parameter in net_d.parameters():
-                    parameter.requires_grad_(True)
+            if loss_gen_all < lowest_value["value"]:
+                lowest_value = {
+                    "step": global_step,
+                    "value": loss_gen_all,
+                    "epoch": epoch,
+                }
+            optim_g.zero_grad()
+            if train_dtype == torch.float16:
+                scaler.scale(loss_gen_all).backward()
+                scaler.unscale_(optim_g)
+                grad_norm_g = commons.grad_norm(net_g.parameters())
+                scaler.step(optim_g)
+                scaler.update()
+            else:
+                loss_gen_all.backward()
+                grad_norm_g = commons.grad_norm(net_g.parameters())
+                optim_g.step()
+            # Unwind the freeze.  A plain restore and not a ``finally``: the
+            # batch loop catches nothing, ``run`` is the process target, so an
+            # exception anywhere above ends this process rather than reaching
+            # another step that a frozen discriminator could spoil.
+            #
+            # Unconditionally ``True`` and not a captured state list: these are
+            # the only ``requires_grad`` writes in the codebase, so every
+            # discriminator parameter is trainable at every step.  A freeze
+            # added anywhere else -- a frozen-D stage, a partial pretrained
+            # load -- makes both paragraphs false, and this is the block to
+            # change.
+            net_d.requires_grad_(True)
 
             global_step += 1
 

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -700,58 +700,97 @@ def train_and_evaluate(
                     grad_norm_d = commons.grad_norm(net_d.parameters())
                     optim_d.step()
 
-            with torch.amp.autocast(
-                device_type="cuda", enabled=use_amp, dtype=train_dtype
-            ):
-                # Generator backward and update
-                _, y_d_hat_g, fmap_r, fmap_g = net_d(wave, y_hat)
+            # The generator update reads the discriminator; it never trains
+            # it.  Its backward still computes a weight gradient for every
+            # branch, and that gradient is thrown away -- ``optim_d.zero_grad``
+            # above and the next iteration's discriminator update bracket it,
+            # and no ``optim_d.step`` runs in between.  Freezing the parameters
+            # skips the weight-gradient half of the discriminator backward
+            # while the gradient that *is* wanted, the one flowing back into
+            # ``y_hat``, is unchanged.  Paired with ``no_grad_real`` below.
+            discriminator_model = net_d.module if hasattr(net_d, "module") else net_d
+            discriminator_parameter_states = [
+                parameter.requires_grad
+                for parameter in discriminator_model.parameters()
+            ]
+            for parameter in discriminator_model.parameters():
+                parameter.requires_grad_(False)
+            try:
+                with torch.amp.autocast(
+                    device_type="cuda", enabled=use_amp, dtype=train_dtype
+                ):
+                    # Generator backward and update.
+                    #
+                    # ``no_grad_real``: the real side is the feature matching
+                    # *target* and its logits are discarded, so differentiating
+                    # it builds a graph nothing consumes.  See
+                    # ``MultiPeriodDiscriminator.forward``.
+                    #
+                    # The unwrapped module, not ``net_d``: under DDP the
+                    # wrapper's forward arms the reducer for a backward that
+                    # will never produce a discriminator gradient, and no
+                    # gradient sync is wanted here in the first place.
+                    _, y_d_hat_g, fmap_r, fmap_g = discriminator_model(
+                        wave, y_hat, no_grad_real=True
+                    )
 
-            if multiscale_mel_loss:
-                loss_mel = fn_mel_loss(wave, y_hat) * config.train.c_mel / 3.0
-            else:
-                wave_mel = mel_spectrogram_torch(
-                    wave.float().squeeze(1),
-                    config.data.filter_length,
-                    config.data.n_mel_channels,
-                    config.data.sample_rate,
-                    config.data.hop_length,
-                    config.data.win_length,
-                    config.data.mel_fmin,
-                    config.data.mel_fmax,
-                )
-                y_hat_mel = mel_spectrogram_torch(
-                    y_hat.float().squeeze(1),
-                    config.data.filter_length,
-                    config.data.n_mel_channels,
-                    config.data.sample_rate,
-                    config.data.hop_length,
-                    config.data.win_length,
-                    config.data.mel_fmin,
-                    config.data.mel_fmax,
-                )
-                loss_mel = fn_mel_loss(wave_mel, y_hat_mel) * config.train.c_mel
-            loss_kl = kl_loss(z_p, logs_q, m_p, logs_p, z_mask) * config.train.c_kl
-            loss_fm = feature_loss(fmap_r, fmap_g)
-            loss_gen, _ = generator_loss(y_d_hat_g)
-            loss_gen_all = loss_gen + loss_fm + loss_mel + loss_kl
+                if multiscale_mel_loss:
+                    loss_mel = fn_mel_loss(wave, y_hat) * config.train.c_mel / 3.0
+                else:
+                    wave_mel = mel_spectrogram_torch(
+                        wave.float().squeeze(1),
+                        config.data.filter_length,
+                        config.data.n_mel_channels,
+                        config.data.sample_rate,
+                        config.data.hop_length,
+                        config.data.win_length,
+                        config.data.mel_fmin,
+                        config.data.mel_fmax,
+                    )
+                    y_hat_mel = mel_spectrogram_torch(
+                        y_hat.float().squeeze(1),
+                        config.data.filter_length,
+                        config.data.n_mel_channels,
+                        config.data.sample_rate,
+                        config.data.hop_length,
+                        config.data.win_length,
+                        config.data.mel_fmin,
+                        config.data.mel_fmax,
+                    )
+                    loss_mel = fn_mel_loss(wave_mel, y_hat_mel) * config.train.c_mel
+                loss_kl = kl_loss(z_p, logs_q, m_p, logs_p, z_mask) * config.train.c_kl
+                loss_fm = feature_loss(fmap_r, fmap_g)
+                loss_gen, _ = generator_loss(y_d_hat_g)
+                loss_gen_all = loss_gen + loss_fm + loss_mel + loss_kl
 
-            if loss_gen_all < lowest_value["value"]:
-                lowest_value = {
-                    "step": global_step,
-                    "value": loss_gen_all,
-                    "epoch": epoch,
-                }
-            optim_g.zero_grad()
-            if train_dtype == torch.float16:
-                scaler.scale(loss_gen_all).backward()
-                scaler.unscale_(optim_g)
-                grad_norm_g = commons.grad_norm(net_g.parameters())
-                scaler.step(optim_g)
-                scaler.update()
-            else:
-                loss_gen_all.backward()
-                grad_norm_g = commons.grad_norm(net_g.parameters())
-                optim_g.step()
+                if loss_gen_all < lowest_value["value"]:
+                    lowest_value = {
+                        "step": global_step,
+                        "value": loss_gen_all,
+                        "epoch": epoch,
+                    }
+                optim_g.zero_grad()
+                if train_dtype == torch.float16:
+                    scaler.scale(loss_gen_all).backward()
+                    scaler.unscale_(optim_g)
+                    grad_norm_g = commons.grad_norm(net_g.parameters())
+                    scaler.step(optim_g)
+                    scaler.update()
+                else:
+                    loss_gen_all.backward()
+                    grad_norm_g = commons.grad_norm(net_g.parameters())
+                    optim_g.step()
+            finally:
+                # ``finally`` and not a plain restore after the step: a raise
+                # anywhere above would otherwise leave every ``net_d``
+                # parameter frozen for the rest of the run, with ``loss_disc``
+                # still logged and ``optim_d.step`` still called -- a
+                # discriminator that has silently stopped learning.
+                for parameter, requires_grad in zip(
+                    discriminator_model.parameters(),
+                    discriminator_parameter_states,
+                ):
+                    parameter.requires_grad_(requires_grad)
 
             global_step += 1
 

--- a/rvc/train/train.py
+++ b/rvc/train/train.py
@@ -709,10 +709,6 @@ def train_and_evaluate(
             # while the gradient that *is* wanted, the one flowing back into
             # ``y_hat``, is unchanged.  Paired with ``no_grad_real`` below.
             discriminator_model = net_d.module if hasattr(net_d, "module") else net_d
-            discriminator_parameter_states = [
-                parameter.requires_grad
-                for parameter in discriminator_model.parameters()
-            ]
             for parameter in discriminator_model.parameters():
                 parameter.requires_grad_(False)
             try:
@@ -786,11 +782,14 @@ def train_and_evaluate(
                 # parameter frozen for the rest of the run, with ``loss_disc``
                 # still logged and ``optim_d.step`` still called -- a
                 # discriminator that has silently stopped learning.
-                for parameter, requires_grad in zip(
-                    discriminator_model.parameters(),
-                    discriminator_parameter_states,
-                ):
-                    parameter.requires_grad_(requires_grad)
+                # Unconditionally ``True`` and not a saved state list: these
+                # four lines are the only ``requires_grad`` in the codebase, so
+                # every discriminator parameter is trainable at every step and
+                # a captured state would restore a constant.  A freeze added
+                # anywhere else -- a frozen-D stage, a partial pretrained load
+                # -- makes that false, and this is the line to change.
+                for parameter in discriminator_model.parameters():
+                    parameter.requires_grad_(True)
 
             global_step += 1
 


### PR DESCRIPTION
This pull request introduces an optimization to the generator update phase of the training loop by preventing unnecessary computation of discriminator gradients when they are not needed. The main changes involve modifying the discriminator's forward pass to optionally skip gradient computation for the "real" branch, and updating the training loop to leverage this for improved efficiency and correctness.

These changes should result in faster generator updates and reduced memory usage during training, while ensuring the discriminator remains trainable and gradients are managed correctly.