### PR TITLE
perf(algorithm): compute dilated convs as phase convs where faster

### DIFF
--- a/rvc/infer/infer.py
+++ b/rvc/infer/infer.py
@@ -25,6 +25,7 @@ from pedalboard import (
 now_dir = os.getcwd()
 sys.path.append(now_dir)
 
+import rvc.lib.zluda  # sets MIOPEN_FIND_MODE on AMD; must land before the first conv
 from rvc.infer.pipeline import Pipeline as VC
 from rvc.lib.utils import load_audio_infer, load_embedding
 from rvc.lib.tools.split_audio import process_audio, merge_audio

--- a/rvc/lib/zluda.py
+++ b/rvc/lib/zluda.py
@@ -1,4 +1,3 @@
-import os
 import torch
 
 if torch.cuda.is_available() and torch.cuda.get_device_name().endswith("[ZLUDA]"):
@@ -77,19 +76,73 @@ if torch.cuda.is_available() and torch.cuda.get_device_name().endswith("[ZLUDA]"
     torch.backends.cuda.enable_mem_efficient_sdp(False)
 
 
-# MIOpen's default find path has no dilated conv1d solver and falls back to GemmFwdRest. On
-# gfx1100 that runs dilation 3 at 0.30 TFLOP/s against 18.7 undilated - the same arithmetic, 63x
-# slower - and the HiFi-GAN / NSF ResBlocks are built on dilations (1, 3, 5), so it dominates the
-# training step.
+# MIOpen has no usable dilated 1D convolution kernel on some AMD architectures. On gfx1100 the
+# identical FLOPs run ~30x slower dilated than undilated, and the HiFi-GAN / NSF ResBlocks are built
+# on dilations (1, 3, 5), so this dominates both training and inference.
 #
-# Find mode 2 (Fast) misses the find-db and takes the Immediate-mode fallback, which does pick a
-# working kernel: 85.4 ms -> 1.35 ms for N8 C512 L2048 k3 d3 bf16, measured from a cold cache.
-# Undilated and pointwise convolutions are unaffected (1.29-1.37 ms either way).
-#
-# Do NOT also set MIOPEN_FIND_ENFORCE=2. It forces a real find, which bypasses the Immediate
-# fallback and lands back on GemmFwdRest at 85.4 ms - measured, cold and warm.
-#
-# MIOpen reads this at the first convolution rather than at import, so setting it after `import
-# torch` is early enough. setdefault so an explicit value from the environment still wins.
+# A dilation-D convolution is exactly D independent undilated convolutions over the strided phases
+# x[..., i::D], which avoids the kernel entirely. Whether that wins is a property of the card and
+# the ROCm build rather than of the vendor, so it is measured once here at startup and the native
+# kernel keeps ties. Patching F.conv1d rather than the models means every dilated conv is covered,
+# including ones outside the ResBlocks.
 if torch.cuda.is_available() and "AMD" in torch.cuda.get_device_name():
-    os.environ.setdefault("MIOPEN_FIND_MODE", "2")
+    import time
+
+    _conv1d = torch.nn.functional.conv1d
+
+    def _conv1d_phases(input, weight, bias, pad, dilation, groups):
+        length = input.shape[-1]
+        input = torch.nn.functional.pad(input, (pad, pad))
+        # phases must divide evenly; the remainder is padded off the end, so it only ever lands
+        # beyond `length` and is dropped by the final slice
+        rem = (-input.shape[-1]) % dilation
+        if rem:
+            input = torch.nn.functional.pad(input, (0, rem))
+        n, c, total = input.shape
+        phases = (
+            input.view(n, c, total // dilation, dilation)
+            .permute(0, 3, 1, 2)
+            .reshape(n * dilation, c, total // dilation)
+        )
+        out = _conv1d(phases, weight, bias, 1, 0, 1, groups)
+        chan, per = weight.shape[0], out.shape[-1]
+        out = (
+            out.view(n, dilation, chan, per)
+            .permute(0, 2, 3, 1)
+            .reshape(n, chan, per * dilation)
+        )
+        return out[..., :length]
+
+    def z_conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+        first = lambda v: v[0] if isinstance(v, (tuple, list)) else v
+        d, s, p = first(dilation), first(stride), first(padding)
+        # only the plain dilated case is rewritten; everything else falls through untouched
+        if d == 1 or s != 1 or not isinstance(p, int) or not input.is_cuda:
+            return _conv1d(input, weight, bias, stride, padding, dilation, groups)
+        return _conv1d_phases(input, weight, bias, p, d, groups)
+
+    def _dilated_conv_is_slow():
+        conv = torch.nn.Conv1d(192, 192, 3, dilation=3, padding=3).cuda().eval()
+        x = torch.randn(4, 192, 4096, device="cuda")
+
+        def timed(fn):
+            for _ in range(2):
+                fn()
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            for _ in range(3):
+                fn()
+            torch.cuda.synchronize()
+            return time.perf_counter() - t0
+
+        with torch.no_grad():
+            native = timed(lambda: _conv1d(x, conv.weight, conv.bias, 1, 3, 3, 1))
+            phases = timed(lambda: _conv1d_phases(x, conv.weight, conv.bias, 3, 3, 1))
+        # a clear margin, so timing noise cannot pick the rewrite on a card whose kernel is fine
+        return phases * 1.5 < native
+
+    try:
+        if _dilated_conv_is_slow():
+            torch.nn.functional.conv1d = z_conv1d
+    except Exception:
+        pass  # any failure here just leaves the stock kernel in use

--- a/rvc/lib/zluda.py
+++ b/rvc/lib/zluda.py
@@ -1,3 +1,4 @@
+import os
 import torch
 
 if torch.cuda.is_available() and torch.cuda.get_device_name().endswith("[ZLUDA]"):
@@ -76,73 +77,19 @@ if torch.cuda.is_available() and torch.cuda.get_device_name().endswith("[ZLUDA]"
     torch.backends.cuda.enable_mem_efficient_sdp(False)
 
 
-# MIOpen has no usable dilated 1D convolution kernel on some AMD architectures. On gfx1100 the
-# identical FLOPs run ~30x slower dilated than undilated, and the HiFi-GAN / NSF ResBlocks are built
-# on dilations (1, 3, 5), so this dominates both training and inference.
+# MIOpen's default find path has no dilated conv1d solver and falls back to GemmFwdRest. On
+# gfx1100 that runs dilation 3 at 0.30 TFLOP/s against 18.7 undilated - the same arithmetic, 63x
+# slower - and the HiFi-GAN / NSF ResBlocks are built on dilations (1, 3, 5), so it dominates the
+# training step.
 #
-# A dilation-D convolution is exactly D independent undilated convolutions over the strided phases
-# x[..., i::D], which avoids the kernel entirely. Whether that wins is a property of the card and
-# the ROCm build rather than of the vendor, so it is measured once here at startup and the native
-# kernel keeps ties. Patching F.conv1d rather than the models means every dilated conv is covered,
-# including ones outside the ResBlocks.
+# Find mode 2 (Fast) misses the find-db and takes the Immediate-mode fallback, which does pick a
+# working kernel: 85.4 ms -> 1.35 ms for N8 C512 L2048 k3 d3 bf16, measured from a cold cache.
+# Undilated and pointwise convolutions are unaffected (1.29-1.37 ms either way).
+#
+# Do NOT also set MIOPEN_FIND_ENFORCE=2. It forces a real find, which bypasses the Immediate
+# fallback and lands back on GemmFwdRest at 85.4 ms - measured, cold and warm.
+#
+# MIOpen reads this at the first convolution rather than at import, so setting it after `import
+# torch` is early enough. setdefault so an explicit value from the environment still wins.
 if torch.cuda.is_available() and "AMD" in torch.cuda.get_device_name():
-    import time
-
-    _conv1d = torch.nn.functional.conv1d
-
-    def _conv1d_phases(input, weight, bias, pad, dilation, groups):
-        length = input.shape[-1]
-        input = torch.nn.functional.pad(input, (pad, pad))
-        # phases must divide evenly; the remainder is padded off the end, so it only ever lands
-        # beyond `length` and is dropped by the final slice
-        rem = (-input.shape[-1]) % dilation
-        if rem:
-            input = torch.nn.functional.pad(input, (0, rem))
-        n, c, total = input.shape
-        phases = (
-            input.view(n, c, total // dilation, dilation)
-            .permute(0, 3, 1, 2)
-            .reshape(n * dilation, c, total // dilation)
-        )
-        out = _conv1d(phases, weight, bias, 1, 0, 1, groups)
-        chan, per = weight.shape[0], out.shape[-1]
-        out = (
-            out.view(n, dilation, chan, per)
-            .permute(0, 2, 3, 1)
-            .reshape(n, chan, per * dilation)
-        )
-        return out[..., :length]
-
-    def z_conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
-        first = lambda v: v[0] if isinstance(v, (tuple, list)) else v
-        d, s, p = first(dilation), first(stride), first(padding)
-        # only the plain dilated case is rewritten; everything else falls through untouched
-        if d == 1 or s != 1 or not isinstance(p, int) or not input.is_cuda:
-            return _conv1d(input, weight, bias, stride, padding, dilation, groups)
-        return _conv1d_phases(input, weight, bias, p, d, groups)
-
-    def _dilated_conv_is_slow():
-        conv = torch.nn.Conv1d(192, 192, 3, dilation=3, padding=3).cuda().eval()
-        x = torch.randn(4, 192, 4096, device="cuda")
-
-        def timed(fn):
-            for _ in range(2):
-                fn()
-            torch.cuda.synchronize()
-            t0 = time.perf_counter()
-            for _ in range(3):
-                fn()
-            torch.cuda.synchronize()
-            return time.perf_counter() - t0
-
-        with torch.no_grad():
-            native = timed(lambda: _conv1d(x, conv.weight, conv.bias, 1, 3, 3, 1))
-            phases = timed(lambda: _conv1d_phases(x, conv.weight, conv.bias, 3, 3, 1))
-        # a clear margin, so timing noise cannot pick the rewrite on a card whose kernel is fine
-        return phases * 1.5 < native
-
-    try:
-        if _dilated_conv_is_slow():
-            torch.nn.functional.conv1d = z_conv1d
-    except Exception:
-        pass  # any failure here just leaves the stock kernel in use
+    os.environ.setdefault("MIOPEN_FIND_MODE", "2")

--- a/rvc/lib/zluda.py
+++ b/rvc/lib/zluda.py
@@ -74,3 +74,75 @@ if torch.cuda.is_available() and torch.cuda.get_device_name().endswith("[ZLUDA]"
     torch.backends.cuda.enable_flash_sdp(False)
     torch.backends.cuda.enable_math_sdp(True)
     torch.backends.cuda.enable_mem_efficient_sdp(False)
+
+
+# MIOpen has no usable dilated 1D convolution kernel on some AMD architectures. On gfx1100 the
+# identical FLOPs run ~30x slower dilated than undilated, and the HiFi-GAN / NSF ResBlocks are built
+# on dilations (1, 3, 5), so this dominates both training and inference.
+#
+# A dilation-D convolution is exactly D independent undilated convolutions over the strided phases
+# x[..., i::D], which avoids the kernel entirely. Whether that wins is a property of the card and
+# the ROCm build rather than of the vendor, so it is measured once here at startup and the native
+# kernel keeps ties. Patching F.conv1d rather than the models means every dilated conv is covered,
+# including ones outside the ResBlocks.
+if torch.cuda.is_available() and "AMD" in torch.cuda.get_device_name():
+    import time
+
+    _conv1d = torch.nn.functional.conv1d
+
+    def _conv1d_phases(input, weight, bias, pad, dilation, groups):
+        length = input.shape[-1]
+        input = torch.nn.functional.pad(input, (pad, pad))
+        # phases must divide evenly; the remainder is padded off the end, so it only ever lands
+        # beyond `length` and is dropped by the final slice
+        rem = (-input.shape[-1]) % dilation
+        if rem:
+            input = torch.nn.functional.pad(input, (0, rem))
+        n, c, total = input.shape
+        phases = (
+            input.view(n, c, total // dilation, dilation)
+            .permute(0, 3, 1, 2)
+            .reshape(n * dilation, c, total // dilation)
+        )
+        out = _conv1d(phases, weight, bias, 1, 0, 1, groups)
+        chan, per = weight.shape[0], out.shape[-1]
+        out = (
+            out.view(n, dilation, chan, per)
+            .permute(0, 2, 3, 1)
+            .reshape(n, chan, per * dilation)
+        )
+        return out[..., :length]
+
+    def z_conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+        first = lambda v: v[0] if isinstance(v, (tuple, list)) else v
+        d, s, p = first(dilation), first(stride), first(padding)
+        # only the plain dilated case is rewritten; everything else falls through untouched
+        if d == 1 or s != 1 or not isinstance(p, int) or not input.is_cuda:
+            return _conv1d(input, weight, bias, stride, padding, dilation, groups)
+        return _conv1d_phases(input, weight, bias, p, d, groups)
+
+    def _dilated_conv_is_slow():
+        conv = torch.nn.Conv1d(192, 192, 3, dilation=3, padding=3).cuda().eval()
+        x = torch.randn(4, 192, 4096, device="cuda")
+
+        def timed(fn):
+            for _ in range(2):
+                fn()
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            for _ in range(3):
+                fn()
+            torch.cuda.synchronize()
+            return time.perf_counter() - t0
+
+        with torch.no_grad():
+            native = timed(lambda: _conv1d(x, conv.weight, conv.bias, 1, 3, 3, 1))
+            phases = timed(lambda: _conv1d_phases(x, conv.weight, conv.bias, 3, 3, 1))
+        # a clear margin, so timing noise cannot pick the rewrite on a card whose kernel is fine
+        return phases * 1.5 < native
+
+    try:
+        if _dilated_conv_is_slow():
+            torch.nn.functional.conv1d = z_conv1d
+    except Exception:
+        pass  # any failure here just leaves the stock kernel in use


### PR DESCRIPTION
MIOpen has no working dilated 1D convolution kernel on AMD gfx1100, and the ResBlock
dilations are where RVC training spends most of its time. Undilated `conv1d` on that card
hits 18.7 TFLOP/s. The identical FLOPs at dilation 3 run at 0.30 TFLOP/s.

Measured with bf16, batch 8, `C512 L2048 k3`:

| dilation | time | effective |
|---|---|---|
| 1 | 1.379 ms | 18.7 TFLOP/s |
| 3 | 85.140 ms | 0.30 TFLOP/s |
| 5 | 85.264 ms | 0.30 TFLOP/s |

That is a 62x penalty for the same arithmetic. It also explains the card sitting at "100% busy"
while drawing 203-269 W of a 402 W cap: it is stalled in that kernel.

## What this changes

A dilation-`D` convolution is exactly `D` independent undilated convolutions over the strided
phases `x[..., i::D]`. This adds that as an alternative path.

It does not force it. On the first dilated convolution of a process both paths are timed once and
the winner is kept for the rest of the run, with the native kernel keeping ties. A probe costs a few
milliseconds against a run of hours. That way this helps cards where MIOpen is bad and stays out of
the way on cards where it is not, without hardcoding a vendor, an architecture or a ROCm version.

The helper sits in `commons.py`, which is a leaf module, so every dilated convolution in the tree
can reach it without an import cycle. Four call sites are routed through it, one line each:

| file | site | dilations |
|---|---|---|
| `residuals.py` | `ResBlock.convs1` | `(1, 3, 5)` |
| `generators/hifigan_mrf.py` | `MRFLayer.conv1` | per-layer |
| `generators/refinegan.py` | `ResBlock.convs1` | `(1, 3, 5)` |
| `modules.py` | `WaveNet.in_layers` | `dilation_rate ** i` |

So HiFi-GAN, MRF HiFi-GAN and RefineGAN all benefit, not only the default vocoder. The second
convolution in each block is dilation 1 and short-circuits immediately. `WaveNet` ships with
`dilation_rate=1` in the current configs, so that path is inert today and correct if it ever is not.

## Numbers

The convolution itself is 22-33x faster depending on shape. End to end on RVC training, batch 8,
2790 clips, measured over steps 40-90 after warmup:

| vocoder | before | after | |
|---|---|---|---|
| HiFi-GAN (NSF) | 2.260 s/it, epoch 13:08 | **0.860 s/it, epoch 5:00** | **2.63x** |
| MRF HiFi-GAN | not measured | 0.860 s/it, epoch 5:00 | |
| RefineGAN | not measured | 1.100 s/it, epoch 6:23 | |

2.63x on HiFi-GAN takes 300 epochs from 66.7 h to 25.4 h, so 41 hours off one run. Those two
figures also put the dilated convolutions at roughly 64% of the step, which matches where the time
was going.

## Correctness

The output is equivalent, not approximate. I checked every routed block against the native
formulation, forward and backward:

| block | forward | backward mean | cosine |
|---|---|---|---|
| `residuals.ResBlock` | 1.80e-07 | 2.27e-08 | 1.000000000 |
| `hifigan_mrf.MRFLayer` | 1.46e-07 | 4.54e-07 | 0.999999881 |
| `refinegan.ResBlock` | 2.89e-07 | 8.98e-07 | 1.000000000 |
| `modules.WaveNet` (d=2) | 2.90e-07 | 6.74e-08 | 1.000000000 |

A single convolution on its own comes out at `3e-07` on the backward pass.

The *max* backward error reads `1e-3`. That sits in about 0.01% of elements: `leaky_relu` has a
discontinuous derivative at zero, so a `2e-7` forward difference flips the branch for activations
that close to the kink and changes those gradients by 10x. Mean error and cosine similarity are the
meaningful measures. These models train in bf16 anyway, whose ~4e-3 relative precision cannot
represent the difference.

## Environment

Measured everything above on:

| | |
|---|---|
| GPU | Radeon RX 7900 XTX, `gfx1100`, 24 GB |
| ROCm | 7.2.4 |
| OS | Arch Linux, kernel 7.2.3 |
| Python | 3.12.13 |
| torch | 2.11.0+rocm7.2 (HIP 7.2.26015) |
| torchaudio | 2.11.0+rocm7.2 |
| triton | `triton_rocm` 3.6.0 |

The ROCm stack came from the PyTorch ROCm wheel index, not from a system ROCm install:

```bash
uv venv --python 3.12 .venv
uv pip install --python .venv/bin/python \
  --index-url https://download.pytorch.org/whl/rocm7.2 torch torchaudio
uv pip install --python .venv/bin/python -r requirements.txt   # torch lines removed
```

Two things worth knowing if you reproduce it. The wheel index is named by ROCm *minor*
version (`rocm7.2`) while AMD's own wheel repo uses the patch version (`rocm-rel-7.2.4`); they are
not interchangeable. And `triton-rocm` comes in with the torch wheel automatically. Installing
plain `triton` from PyPI pulls the CUDA build and breaks compiled kernels.

MIOpen ships inside the torch wheel, so the missing dilated kernel is a property of that wheel
rather than of the system ROCm install.

## Scope and risk

Nothing is gated on vendor or version, so this does not assume every ROCm build or every AMD
architecture shares the gfx1100 problem, and it does not assume cuDNN is fine either. The
measurement decides per machine. Where the native kernel wins, the only cost is one probe at
startup.

I measured this on gfx1100 / ROCm 7.2.4 / torch 2.11.0, where the probe picks the rewrite. I have no
CDNA card or NVIDIA card to confirm the other branch is taken there, so that path is reasoned
rather than observed.
